### PR TITLE
Add `disabled` prop to `<LinkButton>`

### DIFF
--- a/src/components/Button/ButtonTypes.ts
+++ b/src/components/Button/ButtonTypes.ts
@@ -19,6 +19,7 @@ export type BaseProps = {
 };
 
 export type OnlyLinkButtonProps = {
+  disabled?: boolean;
   render?: ReactElement;
 };
 

--- a/src/components/Button/LinkButton.tsx
+++ b/src/components/Button/LinkButton.tsx
@@ -19,6 +19,8 @@ export const LinkButton = forwardRef<HTMLAnchorElement, LinkButtonProps>(
       icon: _icon,
       fixedIcon: _fixedIcon,
       suffixIcon: _suffixIcon,
+      href: _href,
+      disabled = false,
       ...props
     },
     forwardedRef,
@@ -32,9 +34,11 @@ export const LinkButton = forwardRef<HTMLAnchorElement, LinkButtonProps>(
         [styles[variant]]: true,
         [styles[size]]: true,
         [styles.block]: block,
+        [styles.disabled]: disabled,
       },
       className,
     );
+    const href = disabled ? undefined : _href;
 
     const createElement = (props: any, children: ReactNode) => {
       return render ? cloneElement(render, props, children) : <a {...props}>{children}</a>;
@@ -43,6 +47,7 @@ export const LinkButton = forwardRef<HTMLAnchorElement, LinkButtonProps>(
     return createElement(
       {
         className: cls,
+        href,
         ...props,
         ref: forwardedRef,
       },

--- a/src/stories/LinkButton.stories.tsx
+++ b/src/stories/LinkButton.stories.tsx
@@ -113,6 +113,14 @@ export const Default: Story = {
         <LinkButton {...args} size="medium" block variant="secondary" />
         <LinkButton {...args} size="large" block variant="secondary" />
       </div>
+      <div style={{ display: 'flex', flexDirection: 'row', alignItems: 'flex-start', gap: '32px' }}>
+        <LinkButton href="https://vitals.ubie.life/" {...args} disabled />
+        <LinkButton href="https://vitals.ubie.life/" {...args} variant="secondary" disabled />
+        <LinkButton href="https://vitals.ubie.life/" {...args} variant="accent" disabled />
+        <LinkButton href="https://vitals.ubie.life/" {...args} variant="alert" disabled />
+        <LinkButton href="https://vitals.ubie.life/" {...args} variant="text" disabled />
+        <LinkButton href="https://vitals.ubie.life/" {...args} variant="textAlert" disabled />
+      </div>
     </div>
   ),
   args: defaultArgs,


### PR DESCRIPTION
# Overview

ref: https://ubie.atlassian.net/browse/DSGNPB-95

- Add `disabled` prop to `<LinkButton>`
  - Add `.disabled` class
  - `pointer-event` is `none`
  - Empty `href` prop
- Browser Check: Win/Chrome WinF/irefox Edge Mac/Safari AndroidChrome iOS/Safari (simulator) & **Mac Safari/VoiceOver**

Depends on https://github.com/ubie-oss/ubie-ui/pull/6

Open when dependencies are merged due to many diffs