### PR TITLE
chore: 🤖 add reset css on storybook

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,3 +1,4 @@
+import 'modern-css-reset/dist/reset.min.css';
 import '@ubie/design-tokens/dist/tokens.css';
 
 export const parameters = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "ubie-ui",
-  "version": "0.0.1",
+  "name": "@ubie/ubie-ui",
+  "version": "0.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "ubie-ui",
-      "version": "0.0.1",
+      "name": "@ubie/ubie-ui",
+      "version": "0.0.2",
       "license": "Apache-2.0",
       "devDependencies": {
         "@axe-core/playwright": "^4.7.3",
@@ -53,6 +53,7 @@
         "husky": "8.0.3",
         "lint-staged": "14.0.1",
         "markuplint": "3.12.0",
+        "modern-css-reset": "^1.4.0",
         "npm-run-all": "4.1.5",
         "playwright": "^1.38.1",
         "prettier": "3.0.2",
@@ -18592,6 +18593,12 @@
       "engines": {
         "node": ">=0.4.0"
       }
+    },
+    "node_modules/modern-css-reset": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/modern-css-reset/-/modern-css-reset-1.4.0.tgz",
+      "integrity": "sha512-0crZmSFmrxkI7159rvQWjpDhy0u4+Awg/iOycJdlVn0RSeft/a+6BrQHR3IqvmdK25sqt0o6Z5Ap7cWgUee2rw==",
+      "dev": true
     },
     "node_modules/mri": {
       "version": "1.2.0",
@@ -40415,6 +40422,12 @@
           "dev": true
         }
       }
+    },
+    "modern-css-reset": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/modern-css-reset/-/modern-css-reset-1.4.0.tgz",
+      "integrity": "sha512-0crZmSFmrxkI7159rvQWjpDhy0u4+Awg/iOycJdlVn0RSeft/a+6BrQHR3IqvmdK25sqt0o6Z5Ap7cWgUee2rw==",
+      "dev": true
     },
     "mri": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
     "husky": "8.0.3",
     "lint-staged": "14.0.1",
     "markuplint": "3.12.0",
+    "modern-css-reset": "^1.4.0",
     "npm-run-all": "4.1.5",
     "playwright": "^1.38.1",
     "prettier": "3.0.2",


### PR DESCRIPTION
When you develop components on this repository (on Storybook). You review these components behavior without reset css.

`ubie-inc`'s main applications are developed with [`modern-css-reset`](https://github.com/search?q=org%3Aubie-inc%20modern-css-reset&type=code) or [tailwind preflight](https://github.com/search?q=org%3Aubie-inc+%40tailwind+base&type=code) (which uses [`modern-normailze`](https://github.com/sindresorhus/modern-normalize) under the hood), so It makes a difference in behavior if you try to use on them.
Especially in difference between `box-sizing: content-box` and `box-sizing: border-box`

The issues we can see now is like below.
Height of the modals are different, because of the padding is included in specified height or not
<img width="1920" alt="スクリーンショット 2024-03-10 11 09 11" src="https://github.com/ubie-oss/ubie-ui/assets/33568829/336782a2-3aea-4d1b-bf40-1e797921d378">
<img width="1920" alt="スクリーンショット 2024-03-10 11 08 27" src="https://github.com/ubie-oss/ubie-ui/assets/33568829/02c490e2-2c8a-43c8-95f9-6b3e7a3cf8b8">

Height and Width are different, because of the same reason
<img width="1919" alt="スクリーンショット 2024-03-10 11 09 55" src="https://github.com/ubie-oss/ubie-ui/assets/33568829/c1e35f27-13cc-4bb0-96c3-36fc23ed7d4a">

1px width and height difference on `Accordion`, `Input`, `Select`, `TextArea` and `RadioCard`, because of the border is included in height or not.
<img width="1920" alt="スクリーンショット 2024-03-10 11 11 18" src="https://github.com/ubie-oss/ubie-ui/assets/33568829/05af5911-a4f8-499a-ab2c-0a37902efd4b">

I don't know the specific strategies you have.
Maybe you should include reset css on `[design-tokens](https://github.com/ubie-oss/design-tokens)`, so the behavior does not change depending on how you use.
Maybe you should pick one reset css `modern-css-reset` vs `modern-normailze` (tailwind) vs `normalize` (@unocss) as `Ubie inc` as a whole, because it has nit difference.