### PR TITLE
style: 💄 imporove box-sizing & pointer

### DIFF
--- a/src/components/Toggle/Toggle.module.css
+++ b/src/components/Toggle/Toggle.module.css
@@ -1,14 +1,17 @@
 .root {
-  width: 2.75rem;
-  height: 1.25rem;
+  width: 3rem;
+  height: 1.5rem;
   border-radius: 3rem;
-  border-radius: 1.5rem;
   padding: 0.125rem;
-  box-sizing: content-box;
   position: relative;
   display: inline-flex;
   transition: background-color 200ms;
   cursor: pointer;
+}
+
+.root,
+.root * {
+  box-sizing: border-box;
 }
 
 .root:has(input:disabled) {

--- a/src/components/Toggle/Toggle.module.css
+++ b/src/components/Toggle/Toggle.module.css
@@ -3,14 +3,17 @@
   height: 1.25rem;
   border-radius: 3rem;
   border-radius: 1.5rem;
-  padding: 2px;
+  padding: 0.125rem;
+  box-sizing: content-box;
   position: relative;
   display: inline-flex;
   transition: background-color 200ms;
+  cursor: pointer;
 }
 
 .root:has(input:disabled) {
   background-color: var(--color-text-disabled);
+  cursor: default;
 }
 
 .on {


### PR DESCRIPTION
- pointer was always default, added the pointer cursor when it's not disabled.
- After submitting [this PR](https://github.com/ubie-oss/ubie-ui/pull/22), I noticed some of other components has `box-sizing: content-box;`, so I followed it to fix the sizing problems.
  - I personally think we need some change related to the PR, because the other problems mentioned are still true, even if I add box-sizing here. 
  - I wonder why we use `box-sizing: content-box;`, because modern reset or UI library go with `box-sizing: border-box;` on their global or component scoped CSS.
