### PR TITLE
Fix build process

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,9 +2,7 @@
   "name": "@ubie/ubie-ui",
   "version": "0.0.3",
   "description": "React components for creating Ubie applications.",
-  "main": "dist/index.js",
-  "module": "dist/index.mjs",
-  "typings": "dist/index.d.ts",
+  "types": "dist/index.d.ts",
   "files": [
     "README.md",
     "dist"

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -23,5 +23,5 @@ export default defineConfig({
 
 function addMjsExtension(content) {
   // This regex looks for relative import paths that don't have a file extension
-  return content.replace(/from\s+['"](\.\/|\.\.\/)(?![^'"\s]+?\.\w+['"])([^'"\s]+?)['"];/g, "from '$1$2.mjs';");
+  return content.replace(/from\s+['"](\.\/|\.\.\/)(?![^'"\s]+?\/)['"]([^'"\s]+?)['"];/g, "from '$1$2.mjs';");
 }

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -5,5 +5,23 @@ export default defineConfig({
   dts: true,
   format: ['cjs', 'esm'],
   entry: ['src', '!src/**/*.spec.*', '!src/**/*.d.ts'],
+  external: ['react'],
   bundle: false,
+  plugins: [
+    {
+      name: 'fix-esm',
+      renderChunk(_, chunk) {
+        if (this.format === 'esm') {
+          // https://github.com/egoist/tsup/issues/953
+          const code = addMjsExtension(chunk.code);
+          return { code };
+        }
+      },
+    },
+  ],
 });
+
+function addMjsExtension(content) {
+  // This regex looks for relative import paths that don't have a file extension
+  return content.replace(/from\s+['"](\.\/|\.\.\/)(?![^'"\s]+?\.\w+['"])([^'"\s]+?)['"];/g, "from '$1$2.mjs';");
+}


### PR DESCRIPTION
The issue was the workaround Regex below  was replacing relative directory import like `../../` to `../../.mjs`. I improved the Regex so that only file import should be transformed.

```
function addMjsExtension(content) {
  // This regex looks for relative import paths that don't have a file extension
  return content.replace(/from\s+['"](\.\/|\.\.\/)(?![^'"\s]+?\/)['"]([^'"\s]+?)['"];/g, "from '$1$2.mjs';");
}
```

I made sure it works on the application by `npm pack`, install locally and build   