### PR TITLE
feat(Toggle): 🎸 improve style for touch device

### DIFF
--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -12,7 +12,6 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
       children,
       variant = 'primary',
       size = 'large',
-      className,
       block = false,
       icon: _icon,
       fixedIcon: _fixedIcon,
@@ -25,16 +24,13 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
     const icon = _icon === 'default' ? <VariantIcon variant={variant} /> : _icon;
     const fixedIcon = _fixedIcon === 'default' ? <VariantIcon variant={variant} /> : _fixedIcon;
     const suffixIcon = _suffixIcon === 'default' ? <VariantIcon variant={variant} /> : _suffixIcon;
-    const cls = clsx(
-      {
-        [styles.button]: true,
-        [styles[variant]]: true,
-        [styles[size]]: true,
-        [styles.block]: block,
-        [styles.disabled]: !!props.disabled,
-      },
-      className,
-    );
+    const cls = clsx({
+      [styles.button]: true,
+      [styles[variant]]: true,
+      [styles[size]]: true,
+      [styles.block]: block,
+      [styles.disabled]: !!props.disabled,
+    });
     return (
       <button type={type} className={cls} ref={ref} {...props}>
         {fixedIcon && <span className={styles.fixedIcon}>{fixedIcon}</span>}

--- a/src/components/Button/ButtonTypes.ts
+++ b/src/components/Button/ButtonTypes.ts
@@ -58,9 +58,12 @@ export type OnlyLinkButtonProps = {
   render?: ReactElement;
 };
 
-export type ButtonProps = Omit<ButtonHTMLAttributes<HTMLButtonElement>, keyof BaseProps & keyof OnlyButtonProps> &
+export type ButtonProps = Omit<
+  ButtonHTMLAttributes<HTMLButtonElement>,
+  'className' | keyof BaseProps | keyof OnlyButtonProps
+> &
   BaseProps &
   OnlyButtonProps;
-export type LinkButtonProps = Omit<AnchorHTMLAttributes<HTMLAnchorElement>, keyof BaseProps> &
+export type LinkButtonProps = Omit<AnchorHTMLAttributes<HTMLAnchorElement>, 'className' | keyof BaseProps> &
   BaseProps &
   OnlyLinkButtonProps;

--- a/src/components/Button/LinkButton.tsx
+++ b/src/components/Button/LinkButton.tsx
@@ -14,7 +14,6 @@ export const LinkButton = forwardRef<HTMLAnchorElement, LinkButtonProps>(
       children,
       variant = 'primary',
       size = 'large',
-      className,
       block = false,
       icon: _icon,
       fixedIcon: _fixedIcon,
@@ -28,16 +27,13 @@ export const LinkButton = forwardRef<HTMLAnchorElement, LinkButtonProps>(
     const icon = _icon === 'default' ? <VariantIcon variant={variant} /> : _icon;
     const fixedIcon = _fixedIcon === 'default' ? <VariantIcon variant={variant} /> : _fixedIcon;
     const suffixIcon = _suffixIcon === 'default' ? <VariantIcon variant={variant} /> : _suffixIcon;
-    const cls = clsx(
-      {
-        [styles.button]: true,
-        [styles[variant]]: true,
-        [styles[size]]: true,
-        [styles.block]: block,
-        [styles.disabled]: disabled,
-      },
-      className,
-    );
+    const cls = clsx({
+      [styles.button]: true,
+      [styles[variant]]: true,
+      [styles[size]]: true,
+      [styles.block]: block,
+      [styles.disabled]: disabled,
+    });
     const href = disabled ? undefined : _href;
 
     /* eslint-disable-next-line @typescript-eslint/no-explicit-any */

--- a/src/components/Toggle/Toggle.module.css
+++ b/src/components/Toggle/Toggle.module.css
@@ -7,6 +7,7 @@
   display: inline-flex;
   transition: background-color 200ms;
   cursor: pointer;
+  -webkit-tap-highlight-color: transparent;
 }
 
 .root,
@@ -23,16 +24,18 @@
   background-color: var(--color-primary);
 }
 
-.on:hover {
-  background-color: var(--color-primary-darken);
-}
-
 .off {
   background-color: var(--color-ubie-black-400);
 }
 
-.off:hover {
-  background-color: var(--color-ubie-black-700);
+@media (pointer: fine) {
+  .on:hover {
+    background-color: var(--color-primary-darken);
+  }
+
+  .off:hover {
+    background-color: var(--color-ubie-black-700);
+  }
 }
 
 .thumb {

--- a/src/components/Toggle/Toggle.module.css
+++ b/src/components/Toggle/Toggle.module.css
@@ -28,7 +28,7 @@
   background-color: var(--color-ubie-black-400);
 }
 
-@media (pointer: fine) {
+@media (hover: hover) {
   .on:hover {
     background-color: var(--color-primary-darken);
   }


### PR DESCRIPTION
Fix for the review https://github.com/ubie-inc/ofro/pull/3841#issuecomment-2014545155

Side Note I found while making these change.
1. `-webkit-tap-highlight-color` issue
    This is true to every component with touch action (such as `Button`, `Checkbox`, `Radio`, `Accordion` and so on). Should I fix those too? If so, `Button` might need improvement as it dosen't have any style change (like `:active` style).
2.  `@media (pointer: fine)` (possible) issue
    As per the doc, this media query is for [finding pointer](https://developer.mozilla.org/ja/docs/Web/CSS/@media/pointer) issue not the hover capability. There is the [method](https://developer.mozilla.org/ja/docs/Web/CSS/@media/hover#none) for finding if the device can hover specifically. Although it might end up in the same result in most cases, there seems to be the edge case like [this](https://github.com/mui/material-ui/pull/23453#issuecomment-724046299). So I would suggest using `@media (hover: none)` over `@media (pointer: fine)`.
    ex) How the other design systems handle ?
    - Mui seems prefer `@media (hover: none)` https://github.com/search?q=repo%3Amui%2Fmaterial-ui+%28hover%3A+none%29&type=code
    - Chakra not support officially https://github.com/chakra-ui/chakra-ui/issues/6173