### PR TITLE
Delete className prop of Button

### DIFF
--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -12,7 +12,6 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
       children,
       variant = 'primary',
       size = 'large',
-      className,
       block = false,
       icon: _icon,
       fixedIcon: _fixedIcon,
@@ -25,16 +24,13 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
     const icon = _icon === 'default' ? <VariantIcon variant={variant} /> : _icon;
     const fixedIcon = _fixedIcon === 'default' ? <VariantIcon variant={variant} /> : _fixedIcon;
     const suffixIcon = _suffixIcon === 'default' ? <VariantIcon variant={variant} /> : _suffixIcon;
-    const cls = clsx(
-      {
-        [styles.button]: true,
-        [styles[variant]]: true,
-        [styles[size]]: true,
-        [styles.block]: block,
-        [styles.disabled]: !!props.disabled,
-      },
-      className,
-    );
+    const cls = clsx({
+      [styles.button]: true,
+      [styles[variant]]: true,
+      [styles[size]]: true,
+      [styles.block]: block,
+      [styles.disabled]: !!props.disabled,
+    });
     return (
       <button type={type} className={cls} ref={ref} {...props}>
         {fixedIcon && <span className={styles.fixedIcon}>{fixedIcon}</span>}

--- a/src/components/Button/ButtonTypes.ts
+++ b/src/components/Button/ButtonTypes.ts
@@ -58,9 +58,12 @@ export type OnlyLinkButtonProps = {
   render?: ReactElement;
 };
 
-export type ButtonProps = Omit<ButtonHTMLAttributes<HTMLButtonElement>, keyof BaseProps & keyof OnlyButtonProps> &
+export type ButtonProps = Omit<
+  ButtonHTMLAttributes<HTMLButtonElement>,
+  'className' | keyof BaseProps | keyof OnlyButtonProps
+> &
   BaseProps &
   OnlyButtonProps;
-export type LinkButtonProps = Omit<AnchorHTMLAttributes<HTMLAnchorElement>, keyof BaseProps> &
+export type LinkButtonProps = Omit<AnchorHTMLAttributes<HTMLAnchorElement>, 'className' | keyof BaseProps> &
   BaseProps &
   OnlyLinkButtonProps;

--- a/src/components/Button/LinkButton.tsx
+++ b/src/components/Button/LinkButton.tsx
@@ -14,7 +14,6 @@ export const LinkButton = forwardRef<HTMLAnchorElement, LinkButtonProps>(
       children,
       variant = 'primary',
       size = 'large',
-      className,
       block = false,
       icon: _icon,
       fixedIcon: _fixedIcon,
@@ -28,16 +27,13 @@ export const LinkButton = forwardRef<HTMLAnchorElement, LinkButtonProps>(
     const icon = _icon === 'default' ? <VariantIcon variant={variant} /> : _icon;
     const fixedIcon = _fixedIcon === 'default' ? <VariantIcon variant={variant} /> : _fixedIcon;
     const suffixIcon = _suffixIcon === 'default' ? <VariantIcon variant={variant} /> : _suffixIcon;
-    const cls = clsx(
-      {
-        [styles.button]: true,
-        [styles[variant]]: true,
-        [styles[size]]: true,
-        [styles.block]: block,
-        [styles.disabled]: disabled,
-      },
-      className,
-    );
+    const cls = clsx({
+      [styles.button]: true,
+      [styles[variant]]: true,
+      [styles[size]]: true,
+      [styles.block]: block,
+      [styles.disabled]: disabled,
+    });
     const href = disabled ? undefined : _href;
 
     /* eslint-disable-next-line @typescript-eslint/no-explicit-any */


### PR DESCRIPTION
# Overview

- In `ubie-ui`, component styling is done through prop
- ClassName could be specified for Button because the past implementation was used as is.