### PR TITLE
Button: Consider wrapping long characters (e.g., URLs)

### DIFF
--- a/src/components/Button/Button.module.css
+++ b/src/components/Button/Button.module.css
@@ -25,6 +25,7 @@
   text-decoration: none;
   transition: 0.3s cubic-bezier(0.22, 1, 0.36, 1);
   cursor: pointer;
+  overflow-wrap: anywhere;
 }
 
 .button:focus-visible {


### PR DESCRIPTION
# Overview

- Buttons may break layout for long characters
- For example, in the case of a URL
- use `overflow-wrap: anywhere;`
- https://developer.mozilla.org/ja/docs/Web/CSS/overflow-wrap

> To prevent overflow, an otherwise unbreakable string of characters — like a long word or URL — may be broken at any point if there are no otherwise-acceptable break points in the line. No hyphenation character is inserted at the break point. Soft wrap opportunities introduced by the word break are considered when calculating min-content intrinsic sizes.

# Screenshot

before:

![スクリーンショット 2024-03-25 23 02 35](https://github.com/ubie-oss/ubie-ui/assets/10903851/be62e8e2-7cc4-4306-b7fa-e0bf62dc4641)


after:

![スクリーンショット 2024-03-25 23 03 24](https://github.com/ubie-oss/ubie-ui/assets/10903851/f72bd20a-55bf-4d0d-8cc3-ed4340218f5a)
