### PR TITLE
Delete disabled prop of LinkButton

### DIFF
--- a/src/components/Button/ButtonTypes.ts
+++ b/src/components/Button/ButtonTypes.ts
@@ -37,10 +37,6 @@ export type BaseProps = {
    * 後方配置のアイコン
    */
   suffixIcon?: 'default' | ReactNode;
-  /**
-   * ボタンを無効化するかどうか
-   */
-  disabled?: boolean;
 };
 
 export type OnlyButtonProps = {
@@ -49,6 +45,10 @@ export type OnlyButtonProps = {
    * @default button
    */
   type?: HTMLButtonElement['type'];
+  /**
+   * ボタンを無効化するかどうか
+   */
+  disabled?: boolean;
 };
 
 export type OnlyLinkButtonProps = {

--- a/src/components/Button/LinkButton.tsx
+++ b/src/components/Button/LinkButton.tsx
@@ -18,8 +18,6 @@ export const LinkButton = forwardRef<HTMLAnchorElement, LinkButtonProps>(
       icon: _icon,
       fixedIcon: _fixedIcon,
       suffixIcon: _suffixIcon,
-      href: _href,
-      disabled = false,
       ...props
     },
     forwardedRef,
@@ -32,9 +30,7 @@ export const LinkButton = forwardRef<HTMLAnchorElement, LinkButtonProps>(
       [styles[variant]]: true,
       [styles[size]]: true,
       [styles.block]: block,
-      [styles.disabled]: disabled,
     });
-    const href = disabled ? undefined : _href;
 
     /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
     const createElement = (props: any, children: ReactNode) => {
@@ -44,7 +40,6 @@ export const LinkButton = forwardRef<HTMLAnchorElement, LinkButtonProps>(
     return createElement(
       {
         className: cls,
-        href,
         ...props,
         ref: forwardedRef,
       },

--- a/src/stories/LinkButton.stories.tsx
+++ b/src/stories/LinkButton.stories.tsx
@@ -115,16 +115,3 @@ export const Block: Story = {
     </div>
   ),
 };
-
-export const Disabled: Story = {
-  render: () => (
-    <div style={{ display: 'flex', flexDirection: 'row', alignItems: 'flex-start', gap: '32px' }}>
-      <LinkButton {...defaultArgs} disabled />
-      <LinkButton {...defaultArgs} variant="secondary" disabled />
-      <LinkButton {...defaultArgs} variant="accent" disabled />
-      <LinkButton {...defaultArgs} variant="alert" disabled />
-      <LinkButton {...defaultArgs} variant="text" disabled />
-      <LinkButton {...defaultArgs} variant="textAlert" disabled />
-    </div>
-  ),
-};


### PR DESCRIPTION
# Overview

- It is appropriate to remove the href as a disabled expression of the <a> element
- However, if you specify next.js Link in render prop, href is a required property
- disabled is an edge case, so it should be removed once.

# Screenshot

Storybook did not work in my environment, so I tested it by integrating it into the actual product.

https://github.com/ubie-oss/ubie-ui/assets/10903851/d0bcbb30-6601-417f-a542-ca6ac5d2d561

Components addressed by "ユーザー登録をする".
