### PR TITLE
Add Box Component

### DIFF
--- a/src/components/Box/Box.module.css
+++ b/src/components/Box/Box.module.css
@@ -1,0 +1,292 @@
+.box {
+  box-sizing: border-box;
+  display: block;
+}
+
+.box.ptXxs {
+  padding-top: var(--size-spacing-xxs);
+}
+
+.box.ptXs {
+  padding-top: var(--size-spacing-xs);
+}
+
+.box.ptSm {
+  padding-top: var(--size-spacing-sm);
+}
+
+.box.ptMd {
+  padding-top: var(--size-spacing-md);
+}
+
+.box.ptLg {
+  padding-top: var(--size-spacing-lg);
+}
+
+.box.ptXl {
+  padding-top: var(--size-spacing-xl);
+}
+
+.box.ptXxl {
+  padding-top: var(--size-spacing-xxl);
+}
+
+.box.pbXxs {
+  padding-bottom: var(--size-spacing-xxs);
+}
+
+.box.pbXs {
+  padding-bottom: var(--size-spacing-xs);
+}
+
+.box.pbSm {
+  padding-bottom: var(--size-spacing-sm);
+}
+
+.box.pbMd {
+  padding-bottom: var(--size-spacing-md);
+}
+
+.box.pbLg {
+  padding-bottom: var(--size-spacing-lg);
+}
+
+.box.pbXl {
+  padding-bottom: var(--size-spacing-xl);
+}
+
+.box.pbXxl {
+  padding-bottom: var(--size-spacing-xxl);
+}
+
+.box.plXxs {
+  padding-left: var(--size-spacing-xxs);
+}
+
+.box.plXs {
+  padding-left: var(--size-spacing-xs);
+}
+
+.box.plSm {
+  padding-left: var(--size-spacing-sm);
+}
+
+.box.plMd {
+  padding-left: var(--size-spacing-md);
+}
+
+.box.plLg {
+  padding-left: var(--size-spacing-lg);
+}
+
+.box.plXl {
+  padding-left: var(--size-spacing-xl);
+}
+
+.box.plXxl {
+  padding-left: var(--size-spacing-xxl);
+}
+
+.box.prXxs {
+  padding-right: var(--size-spacing-xxs);
+}
+
+.box.prXs {
+  padding-right: var(--size-spacing-xs);
+}
+
+.box.prSm {
+  padding-right: var(--size-spacing-sm);
+}
+
+.box.prMd {
+  padding-right: var(--size-spacing-md);
+}
+
+.box.prLg {
+  padding-right: var(--size-spacing-lg);
+}
+
+.box.prXl {
+  padding-right: var(--size-spacing-xl);
+}
+
+.box.prXxl {
+  padding-right: var(--size-spacing-xxl);
+}
+
+.box.mtXxs {
+  margin-top: var(--size-spacing-xxs);
+}
+
+.box.mtXs {
+  margin-top: var(--size-spacing-xs);
+}
+
+.box.mtSm {
+  margin-top: var(--size-spacing-sm);
+}
+
+.box.mtMd {
+  margin-top: var(--size-spacing-md);
+}
+
+.box.mtLg {
+  margin-top: var(--size-spacing-lg);
+}
+
+.box.mtXl {
+  margin-top: var(--size-spacing-xl);
+}
+
+.box.mtXxl {
+  margin-top: var(--size-spacing-xxl);
+}
+
+.box.mbXxs {
+  margin-bottom: var(--size-spacing-xxs);
+}
+
+.box.mbXs {
+  margin-bottom: var(--size-spacing-xs);
+}
+
+.box.mbSm {
+  margin-bottom: var(--size-spacing-sm);
+}
+
+.box.mbMd {
+  margin-bottom: var(--size-spacing-md);
+}
+
+.box.mbLg {
+  margin-bottom: var(--size-spacing-lg);
+}
+
+.box.mbXl {
+  margin-bottom: var(--size-spacing-xl);
+}
+
+.box.mbXxl {
+  margin-bottom: var(--size-spacing-xxl);
+}
+
+.box.mlXxs {
+  margin-left: var(--size-spacing-xxs);
+}
+
+.box.mlXs {
+  margin-left: var(--size-spacing-xs);
+}
+
+.box.mlSm {
+  margin-left: var(--size-spacing-sm);
+}
+
+.box.mlMd {
+  margin-left: var(--size-spacing-md);
+}
+
+.box.mlLg {
+  margin-left: var(--size-spacing-lg);
+}
+
+.box.mlXl {
+  margin-left: var(--size-spacing-xl);
+}
+
+.box.mlXxl {
+  margin-left: var(--size-spacing-xxl);
+}
+
+.box.mrXxs {
+  margin-right: var(--size-spacing-xxs);
+}
+
+.box.mrXs {
+  margin-right: var(--size-spacing-xs);
+}
+
+.box.mrSm {
+  margin-right: var(--size-spacing-sm);
+}
+
+.box.mrMd {
+  margin-right: var(--size-spacing-md);
+}
+
+.box.mrLg {
+  margin-right: var(--size-spacing-lg);
+}
+
+.box.mrXl {
+  margin-right: var(--size-spacing-xl);
+}
+
+.box.mrXxl {
+  margin-right: var(--size-spacing-xxl);
+}
+
+.box.radiusXs {
+  border-radius: var(--radius-xs);
+}
+
+.box.radiusSm {
+  border-radius: var(--radius-sm);
+}
+
+.box.radiusMd {
+  border-radius: var(--radius-md);
+}
+
+.box.radiusLg {
+  border-radius: var(--radius-lg);
+}
+
+.box.backgroundColorPrimary {
+  background-color: var(--color-background-primary);
+}
+
+.box.backgroundColorPrimaryDarken {
+  background-color: var(--color-background-primary-darken);
+}
+
+.box.backgroundColorAccent {
+  background-color: var(--color-background-accent);
+}
+
+.box.backgroundColorAccentDarken {
+  background-color: var(--color-background-accent-darken);
+}
+
+.box.backgroundColorAlert {
+  background-color: var(--color-background-alert);
+}
+
+.box.backgroundColorGray {
+  background-color: var(--color-background-gray);
+}
+
+.box.backgroundColorWhite {
+  background-color: var(--color-background-white);
+}
+
+.box.borderGray {
+  border: 1px solid var(--color-border);
+}
+
+.box.borderGrayThick {
+  border: 2px solid var(--color-border);
+}
+
+.box.borderPrimary {
+  border: 1px solid var(--color-primary);
+}
+
+.box.borderPrimaryThick {
+  border: 2px solid var(--color-primary);
+}
+
+.box.widthFull {
+  width: 100%;
+}

--- a/src/components/Box/Box.tsx
+++ b/src/components/Box/Box.tsx
@@ -1,8 +1,7 @@
 import clsx from 'clsx';
 import styles from './Box.module.css';
+import { Spacing, Radius, BackgroundColor } from '../../types/style';
 import type { FC, PropsWithChildren } from 'react';
-
-type Spacing = 'xxl' | 'xl' | 'lg' | 'md' | 'sm' | 'xs' | 'xxs';
 
 type Props = {
   pt?: Spacing;
@@ -13,8 +12,8 @@ type Props = {
   mr?: Spacing;
   mb?: Spacing;
   ml?: Spacing;
-  radius?: 'lg' | 'md' | 'sm' | 'xs';
-  backgroundColor?: 'primary' | 'primaryDarken' | 'accent' | 'accentDarken' | 'alert' | 'gray' | 'white';
+  radius?: Radius;
+  backgroundColor?: BackgroundColor;
   border?: 'gray' | 'grayThick' | 'primary' | 'primaryThick';
   width?: 'full';
 };

--- a/src/components/Box/Box.tsx
+++ b/src/components/Box/Box.tsx
@@ -3,7 +3,6 @@ import styles from './Box.module.css';
 import type { FC, PropsWithChildren } from 'react';
 
 type Spacing = 'xxl' | 'xl' | 'lg' | 'md' | 'sm' | 'xs' | 'xxs';
-type Border = 'gray' | 'grayThick' | 'primary' | 'primaryThick';
 
 type Props = {
   pt?: Spacing;
@@ -16,7 +15,7 @@ type Props = {
   ml?: Spacing;
   radius?: 'lg' | 'md' | 'sm' | 'xs';
   backgroundColor?: 'primary' | 'primaryDarken' | 'accent' | 'accentDarken' | 'alert' | 'gray' | 'white';
-  border?: Border;
+  border?: 'gray' | 'grayThick' | 'primary' | 'primaryThick';
   width?: 'full';
 };
 

--- a/src/components/Box/Box.tsx
+++ b/src/components/Box/Box.tsx
@@ -1,0 +1,61 @@
+import clsx from 'clsx';
+import styles from './Box.module.css';
+import type { FC, PropsWithChildren } from 'react';
+
+type Spacing = 'xxl' | 'xl' | 'lg' | 'md' | 'sm' | 'xs' | 'xxs';
+type Border = 'gray' | 'grayThick' | 'primary' | 'primaryThick';
+
+type Props = {
+  pt?: Spacing;
+  pr?: Spacing;
+  pb?: Spacing;
+  pl?: Spacing;
+  mt?: Spacing;
+  mr?: Spacing;
+  mb?: Spacing;
+  ml?: Spacing;
+  radius?: 'lg' | 'md' | 'sm' | 'xs';
+  backgroundColor?: 'primary' | 'primaryDarken' | 'accent' | 'accentDarken' | 'alert' | 'gray' | 'white';
+  border?: Border;
+  width?: 'full';
+};
+
+const capitalize = (str: string) => str.charAt(0).toUpperCase() + str.slice(1);
+
+export const Box: FC<PropsWithChildren<Props>> = ({
+  children,
+  pt,
+  pr,
+  pb,
+  pl,
+  mt,
+  mr,
+  mb,
+  ml,
+  radius,
+  backgroundColor,
+  border,
+  width,
+}) => {
+  return (
+    <div
+      className={clsx([
+        styles.box,
+        pt && styles[`pt${capitalize(pt)}`],
+        pr && styles[`pr${capitalize(pr)}`],
+        pb && styles[`pb${capitalize(pb)}`],
+        pl && styles[`pl${capitalize(pl)}`],
+        mt && styles[`mt${capitalize(mt)}`],
+        mr && styles[`mr${capitalize(mr)}`],
+        mb && styles[`mb${capitalize(mb)}`],
+        ml && styles[`ml${capitalize(ml)}`],
+        radius && styles[`radius${capitalize(radius)}`],
+        backgroundColor && styles[`backgroundColor${capitalize(backgroundColor)}`],
+        border && styles[`border${capitalize(border)}`],
+        width && styles.widthFull,
+      ])}
+    >
+      {children}
+    </div>
+  );
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 export { Accordion } from './components/Accordion/Accordion';
 export { ActionHalfModal } from './components/ActionHalfModal/ActionHalfModal';
 export { ActionModal } from './components/ActionModal/ActionModal';
+export { Box } from './components/Box/Box';
 export { Button } from './components/Button/Button';
 export { LinkButton } from './components/Button/LinkButton';
 export { ErrorMessage } from './components/ErrorMessage/ErrorMessage';

--- a/src/stories/Box.stories.tsx
+++ b/src/stories/Box.stories.tsx
@@ -1,0 +1,166 @@
+import { Meta, StoryObj } from '@storybook/react';
+import { Box, Stack } from '..';
+import type { ComponentProps } from 'react';
+
+export default {
+  component: Box,
+} satisfies Meta<typeof Box>;
+
+const defaultArgs = {
+  children: 'Box',
+  pt: 'md',
+  pr: 'md',
+  pb: 'md',
+  pl: 'md',
+  radius: 'md',
+  backgroundColor: 'primary',
+} satisfies Partial<ComponentProps<typeof Box>>;
+
+type Story = StoryObj<typeof Box>;
+
+export const Default: Story = {
+  args: defaultArgs,
+};
+
+export const BackgroundColor: Story = {
+  render: () => (
+    <div>
+      <Box {...defaultArgs} backgroundColor="primary">
+        Primary
+      </Box>
+      <Box {...defaultArgs} mt="md" backgroundColor="primaryDarken">
+        Primary Darken
+      </Box>
+      <Box {...defaultArgs} mt="md" backgroundColor="accent">
+        Accent
+      </Box>
+      <Box {...defaultArgs} mt="md" backgroundColor="accentDarken">
+        Accent Darken
+      </Box>
+      <Box {...defaultArgs} mt="md" backgroundColor="alert">
+        Alert
+      </Box>
+      <Box {...defaultArgs} mt="md" backgroundColor="gray">
+        Gray
+      </Box>
+      <Box {...defaultArgs} mt="md" backgroundColor="white">
+        White
+      </Box>
+    </div>
+  ),
+};
+
+export const Padding: Story = {
+  render: () => (
+    <div>
+      <Box {...defaultArgs} pt="xxs" pr="xxs" pb="xxs" pl="xxs">
+        xxs
+      </Box>
+      <Box {...defaultArgs} mt="md" pt="xs" pr="xs" pb="xs" pl="xs">
+        xs
+      </Box>
+      <Box {...defaultArgs} mt="md" pt="sm" pr="sm" pb="sm" pl="sm">
+        sm
+      </Box>
+      <Box {...defaultArgs} mt="md" pt="md" pr="md" pb="md" pl="md">
+        md
+      </Box>
+      <Box {...defaultArgs} mt="md" pt="lg" pr="lg" pb="lg" pl="lg">
+        lg
+      </Box>
+      <Box {...defaultArgs} mt="md" pt="xl" pr="xl" pb="xl" pl="xl">
+        xl
+      </Box>
+      <Box {...defaultArgs} mt="md" pt="xxl" pr="xxl" pb="xxl" pl="xxl">
+        xxl
+      </Box>
+    </div>
+  ),
+};
+
+export const Margin: Story = {
+  render: () => (
+    <div>
+      <Box {...defaultArgs} mt="xxs" mr="xxs" mb="xxs" ml="xxs">
+        xxs
+      </Box>
+      <hr />
+      <Box {...defaultArgs} mt="xs" mr="xs" mb="xs" ml="xs">
+        xs
+      </Box>
+      <hr />
+      <Box {...defaultArgs} mt="sm" mr="sm" mb="sm" ml="sm">
+        sm
+      </Box>
+      <hr />
+      <Box {...defaultArgs} mt="md" mr="md" mb="md" ml="md">
+        md
+      </Box>
+      <hr />
+      <Box {...defaultArgs} mt="lg" mr="lg" mb="lg" ml="lg">
+        lg
+      </Box>
+      <hr />
+      <Box {...defaultArgs} mt="xl" mr="xl" mb="xl" ml="xl">
+        xl
+      </Box>
+      <hr />
+      <Box {...defaultArgs} mt="xxl" mr="xxl" mb="xxl" ml="xxl">
+        xxl
+      </Box>
+    </div>
+  ),
+};
+
+export const Radius: Story = {
+  render: () => (
+    <div>
+      <Box {...defaultArgs} pt="md" pr="md" pb="md" pl="md" radius="xs">
+        xs
+      </Box>
+      <Box {...defaultArgs} mt="md" pt="md" pr="md" pb="md" pl="md" radius="sm">
+        sm
+      </Box>
+      <Box {...defaultArgs} mt="md" pt="md" pr="md" pb="md" pl="md" radius="md">
+        md
+      </Box>
+      <Box {...defaultArgs} mt="md" pt="md" pr="md" pb="md" pl="md" radius="lg">
+        lg
+      </Box>
+    </div>
+  ),
+};
+
+export const Border: Story = {
+  render: () => (
+    <div>
+      <Box {...defaultArgs} backgroundColor="white" border="gray">
+        Border Gray
+      </Box>
+      <Box mt="md" {...defaultArgs} backgroundColor="white" border="grayThick">
+        Border Gray Thick
+      </Box>
+      <Box {...defaultArgs} mt="md" backgroundColor="white" border="primary">
+        Primary Border
+      </Box>
+      <Box {...defaultArgs} mt="md" backgroundColor="white" border="primaryThick">
+        Primary Border Thick
+      </Box>
+    </div>
+  ),
+};
+
+export const Width: Story = {
+  render: () => (
+    <Stack spacing="md">
+      <p>
+        Flexコンテナの子要素では、デフォルトでは横幅がintrinsic（コンテンツに応じた幅）となります。widthをfullとすることで100%を維持できます。
+      </p>
+      <Box {...defaultArgs} width="full">
+        Width Full
+      </Box>
+
+      <Box {...defaultArgs}>Not Width Full</Box>
+    </Stack>
+  ),
+};

--- a/src/types/style.ts
+++ b/src/types/style.ts
@@ -2,7 +2,7 @@ export type FontSize = 'xs' | 'sm' | 'md' | 'lg' | 'xl';
 export type TextType = 'body' | 'heading' | 'note' | 'button' | 'tag';
 export type Leading = 'default' | 'narrow' | 'tight';
 export type TextColor = 'main' | 'sub' | 'link' | 'linkSub' | 'disabled' | 'primary' | 'accent' | 'alert' | 'white';
-export type Spacing = 'xxs' | 'xs' | 'sm' | 'md' | 'lg' | 'xl';
+export type Spacing = 'xxs' | 'xs' | 'sm' | 'md' | 'lg' | 'xl' | 'xxl';
 export type FlexDirection = 'row' | 'column';
 export type AlignItems = 'normal' | 'flex-start' | 'center' | 'flex-end' | 'stretch' | 'baseline';
 export type JustifyContent =
@@ -13,3 +13,5 @@ export type JustifyContent =
   | 'space-between'
   | 'space-around'
   | 'space-evenly';
+export type Radius = 'xs' | 'sm' | 'md' | 'lg';
+export type BackgroundColor = 'primary' | 'primaryDarken' | 'accent' | 'accentDarken' | 'alert' | 'gray' | 'white';


### PR DESCRIPTION
# Motivation

- Many styles in Ubie have the look of a box
- Componentization can reduce a lot of CSS
- It can also be used for fine margin adjustment 
  - e.g. `<Box mt="md" />`

# Screenshot

`npm run storybook`

## Background Color

http://localhost:6006/?path=/story/stories-box--background-color

![スクリーンショット 2024-04-11 14 45 28](https://github.com/ubie-oss/ubie-ui/assets/10903851/8343dc00-8f60-4817-b96f-0819d2d4315a)

## Padding

http://localhost:6006/?path=/story/stories-box--padding

![スクリーンショット 2024-04-11 14 46 19](https://github.com/ubie-oss/ubie-ui/assets/10903851/ab643596-1a62-4cd5-bba2-3e8b176fef4d)

## Margin

http://localhost:6006/?path=/story/stories-box--margin

![スクリーンショット 2024-04-11 14 47 22](https://github.com/ubie-oss/ubie-ui/assets/10903851/50544ec6-1ff1-4603-8bb1-f8355cc2e6b8)

## Radius

http://localhost:6006/?path=/story/stories-box--radius

![スクリーンショット 2024-04-11 14 47 38](https://github.com/ubie-oss/ubie-ui/assets/10903851/34052c32-8bfc-4fc1-91ea-022b18f286a8)

## Border

http://localhost:6006/?path=/story/stories-box--border

![スクリーンショット 2024-04-11 14 47 56](https://github.com/ubie-oss/ubie-ui/assets/10903851/b97ec69c-0b0e-469f-a3bc-2d88b3a4df05)

## Width

http://localhost:6006/?path=/story/stories-box--width

![スクリーンショット 2024-04-11 14 48 22](https://github.com/ubie-oss/ubie-ui/assets/10903851/1ca05345-b577-476a-9272-ab25ab56fefe)
