### PR TITLE
Add Caret to LinkCard component

### DIFF
--- a/src/components/LinkCard/LinkCard.module.css
+++ b/src/components/LinkCard/LinkCard.module.css
@@ -1,5 +1,6 @@
 .card {
   display: flex;
+  align-items: center;
   gap: var(--size-spacing-md);
   padding: var(--size-spacing-md);
   border: 1px solid var(--color-border);
@@ -18,6 +19,7 @@
 }
 
 .text {
+  flex: 1;
   display: flex;
   flex-direction: column;
   gap: var(--size-spacing-xxs);
@@ -36,4 +38,10 @@
   font-size: var(--text-note-lg-size);
   line-height: var(--text-note-lg-line);
   color: var(--color-text-sub);
+}
+
+.caret {
+  color: var(--color-primary);
+  width: 20px;
+  height: 20px;
 }

--- a/src/components/LinkCard/LinkCard.tsx
+++ b/src/components/LinkCard/LinkCard.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { UrlObject } from 'url';
+import { ArrowBRightIcon } from '@ubie/ubie-icons';
 import clsx from 'clsx';
 import { ComponentType, ElementType, FC, ReactNode } from 'react';
 import styles from './LinkCard.module.css';
@@ -48,6 +49,7 @@ export const LinkCard: FC<Props> = ({
         <p className={styles.title}>{title}</p>
         <p className={styles.description}>{description}</p>
       </div>
+      <ArrowBRightIcon className={styles.caret} />
     </LinkComponent>
   );
 };


### PR DESCRIPTION
I propose adding a caret icon to the LinkCard component to more clearly indicate that it is not just a card, but an interactive link. This visual enhancement will help users understand at a glance that the card is clickable and will lead them to additional content or actions. The caret symbol is widely recognized as an indicator for links or dropdowns, making it an intuitive choice for this purpose.

## Screenshots

<img width="1067" alt="image" src="https://github.com/ubie-oss/ubie-ui/assets/86085/b6c57d17-60c1-4ea6-b0b1-f7eefefc29be">
