### PR TITLE
Workaround to change the lang attribute on storybook

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -1,0 +1,3 @@
+<script>
+  document.documentElement.setAttribute('lang', 'ja');
+</script>


### PR DESCRIPTION
To render `<html lang="ja">` on storybook.

Ref: https://github.com/storybookjs/storybook/issues/11706

|Before|After|
|---|---|
|<img width="1065" alt="image" src="https://github.com/ubie-oss/ubie-ui/assets/86085/dfd92c28-f99c-4c6e-815c-9a875a442a56">|<img width="1065" alt="image" src="https://github.com/ubie-oss/ubie-ui/assets/86085/406d246f-697a-43d7-ba01-18d750b344a9">|

