### PR TITLE
LinkCard Without Description and in a Smaller Size

### DIFF
--- a/src/components/LinkCard/LinkCard.module.css
+++ b/src/components/LinkCard/LinkCard.module.css
@@ -1,7 +1,7 @@
 .card {
   display: flex;
   align-items: center;
-  gap: var(--size-spacing-md);
+  gap: var(--size-spacing-sm);
   padding: var(--size-spacing-md);
   border: 1px solid var(--color-border);
   border-radius: var(--radius-md);
@@ -14,7 +14,7 @@
 
 .icon {
   flex: none;
-  font-size: 2.5rem;
+  font-size: var(--icon-size);
   color: var(--color-primary);
 }
 
@@ -27,21 +27,35 @@
 
 .title {
   margin: 0;
-  font-size: var(--text-heading-xs-size);
+  font-size: var(--title-font-size);
   font-weight: bold;
-  line-height: var(--text-heading-xs-line);
   color: var(--color-text-main);
 }
 
 .description {
   margin: 0;
-  font-size: var(--text-note-lg-size);
-  line-height: var(--text-note-lg-line);
+  font-size: var(--description-font-size);
+  line-height: var(--description-line-height);
   color: var(--color-text-sub);
 }
 
 .caret {
   color: var(--color-primary);
-  width: 20px;
-  height: 20px;
+  width: 1.25rem;
+  height: 1.25rem;
+}
+
+/* Size */
+.medium {
+  --icon-size: 2rem;
+  --title-font-size: var(--text-heading-xs-line);
+  --description-font-size: var(--text-note-lg-size);
+  --description-line-height: var(--text-note-lg-line);
+}
+
+.small {
+  --icon-size: 1.25rem;
+  --title-font-size: var(--text-button-md-size);
+  --description-font-size: var(--text-note-md-size);
+  --description-line-height: var(--text-note-md-line);
 }

--- a/src/components/LinkCard/LinkCard.tsx
+++ b/src/components/LinkCard/LinkCard.tsx
@@ -12,13 +12,17 @@ type Props = {
    */
   href: string;
   /**
+   * サイズ
+   */
+  size?: 'medium' | 'small';
+  /**
    * 見出しのテキスト
    */
   title: string;
   /**
    * 説明のテキスト
    */
-  description: string;
+  description?: string;
   /**
    * CSSのクラス
    */
@@ -37,17 +41,18 @@ type Props = {
 export const LinkCard: FC<Props> = ({
   href,
   title,
+  size = 'medium',
   className,
   icon: IconComponent,
   description,
   linkComponent: LinkComponent = 'a',
 }) => {
   return (
-    <LinkComponent href={href} className={clsx(styles.card, className)}>
+    <LinkComponent href={href} className={clsx(styles[size], styles.card, className)}>
       {IconComponent && <IconComponent className={styles.icon} />}
       <div className={styles.text}>
         <p className={styles.title}>{title}</p>
-        <p className={styles.description}>{description}</p>
+        {description && <p className={styles.description}>{description}</p>}
       </div>
       <ArrowBRightIcon className={styles.caret} />
     </LinkComponent>

--- a/src/stories/LinkCard.stories.tsx
+++ b/src/stories/LinkCard.stories.tsx
@@ -1,5 +1,5 @@
 import { Meta, StoryObj } from '@storybook/react';
-import { MedicalFormIcon } from '@ubie/ubie-icons';
+import { HospitalIcon } from '@ubie/ubie-icons';
 import { LinkCard, Stack } from '..';
 
 export default {
@@ -7,14 +7,12 @@ export default {
 } satisfies Meta<typeof LinkCard>;
 
 const defaultArgs = {
-  title: 'タイトル',
-  description:
-    'これはこのカードの遷移先の説明です。これはこのカードの遷移先の説明です。これはこのカードの遷移先の説明です。これはこのカードの遷移先の説明です。これはこのカードの遷移先の説明です。',
+  title: '見出しテキスト',
 };
 
 export const Default: StoryObj<typeof LinkCard> = {
   render: (args) => (
-    <Stack spacing="md">
+    <Stack spacing="md" alignItems="normal">
       <LinkCard {...args} href="/" />
       <LinkCard {...args} href="/" />
     </Stack>
@@ -23,6 +21,15 @@ export const Default: StoryObj<typeof LinkCard> = {
 };
 
 export const WithIcon: StoryObj<typeof LinkCard> = {
-  render: (args) => <LinkCard {...args} href="/" icon={MedicalFormIcon} />,
+  render: (args) => <LinkCard {...args} href="/" icon={HospitalIcon} />,
   args: defaultArgs,
+};
+
+export const WithDescription: StoryObj<typeof LinkCard> = {
+  render: (args) => <LinkCard {...args} href="/" icon={HospitalIcon} />,
+  args: {
+    ...defaultArgs,
+    description:
+      'これはこのカードの遷移先の説明です。これはこのカードの遷移先の説明です。これはこのカードの遷移先の説明です。これはこのカードの遷移先の説明です。これはこのカードの遷移先の説明です。',
+  },
 };


### PR DESCRIPTION
In certain scenarios, there is a need to use the LinkCard component without a description and in a smaller size. This pull request introduces the ability to omit the description for a cleaner, more minimalistic card appearance, and adds a small size option to accommodate contexts where space is limited or a subtler card is desired. These enhancements increase the flexibility and adaptability of the LinkCard component to various design requirements.

<img width="332" alt="image" src="https://github.com/ubie-oss/ubie-ui/assets/86085/42b0ed21-15b0-44e7-aba1-7f0971f521bf">


## Screenshots

### Medium size (default) with a description

<img width="899" alt="image" src="https://github.com/ubie-oss/ubie-ui/assets/86085/e94ededb-3590-4548-b7f6-b1a6ec48e1f1">

### Small size with a description

<img width="899" alt="image" src="https://github.com/ubie-oss/ubie-ui/assets/86085/f9d2900f-600f-4e23-812e-29e2b17e0855">

### Medium size without a description

<img width="899" alt="image" src="https://github.com/ubie-oss/ubie-ui/assets/86085/03a410b1-eb2e-4598-b303-29cea40b82c3">

### Small size without a description

<img width="899" alt="image" src="https://github.com/ubie-oss/ubie-ui/assets/86085/0de60e19-0af3-492d-828b-07f6c24a71e5">
