### PR TITLE
fix: 🐛 Release action auth error

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,9 @@ jobs:
           node-version: 20
           registry-url: 'https://registry.npmjs.org'
 
+      - name: Explicitly set .npmrc
+        run: echo '//registry.npmjs.org/:_authToken=${NPM_TOKEN}' > .npmrc
+
       - name: Install
         run: npm ci
       - name: Build


### PR DESCRIPTION
Since I don't have authority to fire this action on this repo.
I tested on my abandoned repo. See it works fine and what is the result here. https://github.com/kodai3/kodai3/actions