### PR TITLE
reset <Text> margin

### DIFF
--- a/src/components/Text/Text.module.css
+++ b/src/components/Text/Text.module.css
@@ -4,6 +4,11 @@
   color: var(--color);
 }
 
+:where(.text) {
+  margin-top: 0;
+  margin-bottom: 0;
+}
+
 .bold {
   font-weight: bold;
 }


### PR DESCRIPTION
# Overview

- Browser default margins were given.
- If Text component is used, it should be set with Layout component. margin is in the way
- There is a possibility that some products may want to add a global style, so this is `:where`