### PR TITLE
Improve <Text> Types

### DIFF
--- a/src/components/Text/Text.tsx
+++ b/src/components/Text/Text.tsx
@@ -3,29 +3,14 @@
 import { clsx } from 'clsx';
 import { FC, ElementType, ReactNode } from 'react';
 import styles from './Text.module.css';
-import { FontSize, Leading, TextColor, TextType } from '../../types/style';
+import { TextColor } from '../../types/style';
 
-type Props = {
+type BaseProps = {
   /**
    * コンポーネントのHTML要素
    * @default p
    */
   as?: ElementType<{ className?: string; children: ReactNode }>;
-  /**
-   * フォントサイズの抽象値
-   * @default md
-   */
-  size?: FontSize;
-  /**
-   * テキストの種類
-   * @default body
-   */
-  type?: TextType;
-  /**
-   * 行送りの抽象値（`line-height`）
-   * @default default
-   */
-  leading?: Leading;
   /**
    * 太字とするかどうか
    */
@@ -45,10 +30,94 @@ type Props = {
   className?: string;
 };
 
+type BodyFontSize = 'sm' | 'md' | 'lg';
+type BodyLeading = 'default' | 'narrow' | 'tight';
+type BodyProps = BaseProps & {
+  /**
+   * テキストの種類
+   */
+  type?: 'body';
+  /**
+   * フォントサイズの抽象値
+   */
+  size?: BodyFontSize;
+  /**
+   * 行送りの抽象値（`line-height`）
+   */
+  leading?: BodyLeading;
+};
+
+type HeadingFontSize = 'xs' | 'sm' | 'md' | 'lg' | 'xl';
+type HeadingProps = BaseProps & {
+  /**
+   * テキストの種類
+   */
+  type: 'heading';
+  /**
+   * フォントサイズの抽象値
+   */
+  size?: HeadingFontSize;
+  /**
+   * 行送りの抽象値（`line-height`）
+   */
+  leading?: 'default';
+};
+
+type NoteFontSize = 'sm' | 'md' | 'lg';
+type NoteLeading = 'default' | 'narrow' | 'tight';
+type NoteProps = BaseProps & {
+  /**
+   * テキストの種類
+   */
+  type: 'note';
+  /**
+   * フォントサイズの抽象値
+   */
+  size?: NoteFontSize;
+  /**
+   * 行送りの抽象値（`line-height`）
+   */
+  leading?: NoteLeading;
+};
+
+type ButtonFontSize = 'sm' | 'md' | 'lg';
+type ButtonProps = BaseProps & {
+  /**
+   * テキストの種類
+   */
+  type: 'button';
+  /**
+   * フォントサイズの抽象値
+   */
+  size?: ButtonFontSize;
+  /**
+   * 行送りの抽象値（`line-height`）
+   */
+  leading?: 'default';
+};
+
+type TagFontSize = 'sm' | 'md' | 'lg';
+type TagProps = BaseProps & {
+  /**
+   * テキストの種類
+   */
+  type: 'tag';
+  /**
+   * フォントサイズの抽象値
+   */
+  size?: TagFontSize;
+  /**
+   * 行送りの抽象値（`line-height`）
+   */
+  leading?: 'default';
+};
+
+type TextProps = BodyProps | HeadingProps | NoteProps | ButtonProps | TagProps;
+
 /**
  * Design Systemに則ったTypographyのスタイルを提供
  */
-export const Text: FC<Props> = ({
+export const Text: FC<TextProps> = ({
   as: TextComponent = 'p',
   size = 'md',
   type = 'body',

--- a/src/stories/Text.stories.tsx
+++ b/src/stories/Text.stories.tsx
@@ -10,7 +10,7 @@ type Story = StoryObj<typeof Text>;
 const defaultArgs = {};
 export const Default: Story = {
   render: () => (
-    <Text as="h1" type="heading" size="xl" leading="tight" color="primary">
+    <Text as="h1" type="heading" size="xl" color="primary">
       Dummy Text
     </Text>
   ),


### PR DESCRIPTION
# Overview

- An impossible combination of props was possible.
- Using Overload to make an error

# Screenshot

![スクリーンショット 2024-04-15 9 46 09](https://github.com/ubie-oss/ubie-ui/assets/10903851/c258448e-973f-4ceb-b6a3-6eb9752650d5)

Heading don't have leading prop variation.