### PR TITLE
Delete direction prop from Stack Component

### DIFF
--- a/src/components/Box/Box.tsx
+++ b/src/components/Box/Box.tsx
@@ -2,10 +2,16 @@ import clsx from 'clsx';
 import styles from './Box.module.css';
 import {} from '../../types/style';
 import { paddingVariables, marginVariables, radiusVariables } from '../../utils/style';
+import { HTMLTagname } from '../../utils/types';
 import type { PaddingProps, MarginProps, RadiusProp, BackgroundColor } from '../../types/style';
 import type { FC, PropsWithChildren } from 'react';
 
 type Props = {
+  /**
+   * レンダリングされるHTML要素
+   * @default div
+   */
+  as?: HTMLTagname;
   /**
    * 背景色
    */
@@ -25,6 +31,7 @@ type Props = {
 const capitalize = (str: string) => str.charAt(0).toUpperCase() + str.slice(1);
 
 export const Box: FC<PropsWithChildren<Props>> = ({
+  as: BoxCopmonent = 'div',
   children,
   pt,
   pr,
@@ -40,7 +47,7 @@ export const Box: FC<PropsWithChildren<Props>> = ({
   width,
 }) => {
   return (
-    <div
+    <BoxCopmonent
       className={clsx([
         styles.box,
         backgroundColor && styles[`backgroundColor${capitalize(backgroundColor)}`],
@@ -64,6 +71,6 @@ export const Box: FC<PropsWithChildren<Props>> = ({
       }}
     >
       {children}
-    </div>
+    </BoxCopmonent>
   );
 };

--- a/src/components/Center/Center.tsx
+++ b/src/components/Center/Center.tsx
@@ -1,10 +1,16 @@
 import clsx from 'clsx';
 import styles from './Center.module.css';
 import { paddingVariables } from '../../utils/style';
+import { HTMLTagname } from '../../utils/types';
 import type { PaddingProps } from '../../types/style';
 import type { FC, PropsWithChildren, CSSProperties } from 'react';
 
 type Props = {
+  /**
+   * レンダリングされるHTML要素
+   * @default div
+   */
+  as?: HTMLTagname;
   /**
    * 内包するテキストを中央に配置。設定は継承され、子孫要素にも影響します
    */
@@ -24,6 +30,7 @@ type Props = {
 } & PaddingProps;
 
 export const Center: FC<PropsWithChildren<Props>> = ({
+  as: CenterCopmonent = 'div',
   children,
   pt,
   pr,
@@ -35,7 +42,7 @@ export const Center: FC<PropsWithChildren<Props>> = ({
   maxWidth = 'none',
 }) => {
   return (
-    <div
+    <CenterCopmonent
       id={id}
       className={clsx(styles.center, textCenter && styles.textCenter, childrenCenter && styles.childrenCenter)}
       style={
@@ -51,6 +58,6 @@ export const Center: FC<PropsWithChildren<Props>> = ({
       }
     >
       {children}
-    </div>
+    </CenterCopmonent>
   );
 };

--- a/src/components/CheckboxGroup/CheckboxGroup.tsx
+++ b/src/components/CheckboxGroup/CheckboxGroup.tsx
@@ -2,7 +2,7 @@
 
 import styles from './CheckboxGroup.module.css';
 import { Checkbox } from '../Checkbox/Checkbox';
-import { Stack } from '../Stack/Stack';
+import { Flex } from '../Flex/Flex';
 import type { FC, ReactElement } from 'react';
 
 export type Props = {
@@ -15,9 +15,9 @@ export const CheckboxGroup: FC<Props> = ({ children, label, direction = 'column'
   return (
     <fieldset className={styles.wrapper}>
       <legend className={styles.legend}>{label}</legend>
-      <Stack spacing="md" direction={direction}>
+      <Flex spacing="md" direction={direction}>
         {children}
-      </Stack>
+      </Flex>
     </fieldset>
   );
 };

--- a/src/components/Flex/Flex.tsx
+++ b/src/components/Flex/Flex.tsx
@@ -1,9 +1,15 @@
 import clsx from 'clsx';
 import styles from './Flex.module.css';
 import { Spacing, AlignItems, JustifyContent, FlexDirection } from '../../types/style';
+import { HTMLTagname } from '../../utils/types';
 import type { FC, PropsWithChildren } from 'react';
 
 type Props = {
+  /**
+   * レンダリングされるHTML要素
+   * @default div
+   */
+  as?: HTMLTagname;
   /**
    * 子要素同士の間隔
    */
@@ -39,6 +45,7 @@ type Props = {
 };
 
 export const Flex: FC<PropsWithChildren<Props>> = ({
+  as: FlexCopmonent = 'div',
   children,
   direction = 'row',
   alignItems = 'flex-start',
@@ -52,7 +59,7 @@ export const Flex: FC<PropsWithChildren<Props>> = ({
   const gapStyle = spacing ? `var(--size-spacing-${spacing})` : '0';
 
   return (
-    <div
+    <FlexCopmonent
       className={clsx(styles.flex, height === 'full' && styles.heightFull, width === 'full' && styles.widthFull)}
       style={
         {
@@ -65,6 +72,6 @@ export const Flex: FC<PropsWithChildren<Props>> = ({
       }
     >
       {children}
-    </div>
+    </FlexCopmonent>
   );
 };

--- a/src/components/RadioGroup/RadioGroup.tsx
+++ b/src/components/RadioGroup/RadioGroup.tsx
@@ -1,9 +1,9 @@
 'use client';
 
 import styles from './RadioGroup.module.css';
+import { Flex } from '../Flex/Flex';
 import { RadioButton } from '../RadioButton/RadioButton';
 import { RadioCard } from '../RadioCard/RadioCard';
-import { Stack } from '../Stack/Stack';
 import type { FC, ReactElement } from 'react';
 
 type RadioComponent = ReactElement<typeof RadioButton> | ReactElement<typeof RadioCard>;
@@ -21,13 +21,13 @@ export const RadioGroup: FC<Props> = ({ children, label, direction = 'column' })
   return (
     <fieldset className={styles.wrapper}>
       <legend className={styles.legend}>{label}</legend>
-      <Stack
+      <Flex
         spacing={childrenIsCard ? 'sm' : 'md'}
         alignItems={childenIsBlock ? 'normal' : undefined}
         direction={direction}
       >
         {children}
-      </Stack>
+      </Flex>
     </fieldset>
   );
 };

--- a/src/components/Stack/Stack.module.css
+++ b/src/components/Stack/Stack.module.css
@@ -1,3 +1,4 @@
 .stack {
   display: flex;
+  flex-direction: column;
 }

--- a/src/components/Stack/Stack.tsx
+++ b/src/components/Stack/Stack.tsx
@@ -1,25 +1,21 @@
 'use client';
 
 import { clsx } from 'clsx';
-import { ElementType, FC, ReactNode } from 'react';
+import { FC, ReactNode } from 'react';
 import styles from './Stack.module.css';
-import { Spacing, FlexDirection, AlignItems, JustifyContent } from '../../types/style';
+import { Spacing, AlignItems, JustifyContent } from '../../types/style';
+import { HTMLTagname } from '../../utils/types';
 
 type Props = {
   /**
    * レンダリングされるコンポーネントまたはHTML要素
    * @default div
    */
-  as?: ElementType<{ className?: string; children: ReactNode }>;
+  as?: HTMLTagname;
   /**
    * 子要素の間隔
    */
   spacing: Spacing;
-  /**
-   * direction 重ねる向き
-   * @default column
-   */
-  direction?: FlexDirection;
   /**
    * 主軸方向における子要素のレイアウトを定める。`direction` prop が `column` の場合は水平軸、 `row` の場合は垂直軸のレイアウトを制御する。水平軸の場合に、ブロックレベル要素を幅いっぱいに占有させたい場合は `normal` を使うこと
    * @default flex-start
@@ -49,14 +45,12 @@ export const Stack: FC<Props> = ({
   children,
   className,
   spacing,
-  direction = 'column',
   alignItems = 'flex-start',
   justifyContent = 'flex-start',
 }) => {
   return (
     <StackComponent
       style={{
-        flexDirection: `${direction}`,
         alignItems: `${alignItems}`,
         justifyContent: `${justifyContent}`,
         gap: `var(--size-spacing-${spacing})`,

--- a/src/components/Text/Text.tsx
+++ b/src/components/Text/Text.tsx
@@ -1,16 +1,17 @@
 'use client';
 
 import { clsx } from 'clsx';
-import { FC, ElementType, ReactNode } from 'react';
+import { FC, ReactNode } from 'react';
 import styles from './Text.module.css';
 import { TextColor } from '../../types/style';
+import { HTMLTagname } from '../../utils/types';
 
 type BaseProps = {
   /**
    * コンポーネントのHTML要素
    * @default p
    */
-  as?: ElementType<{ className?: string; children: ReactNode }>;
+  as?: HTMLTagname;
   /**
    * 太字とするかどうか
    */

--- a/src/stories/Box.stories.tsx
+++ b/src/stories/Box.stories.tsx
@@ -164,3 +164,13 @@ export const Width: Story = {
     </Stack>
   ),
 };
+
+export const AsSection: Story = {
+  render: () => (
+    <Box as="section" pt="md" pr="md" pb="md" pl="md" radius="md" backgroundColor="primary">
+      <h2>Heading</h2>
+
+      <p>body</p>
+    </Box>
+  ),
+};

--- a/src/stories/Center.stories.tsx
+++ b/src/stories/Center.stories.tsx
@@ -48,3 +48,13 @@ export const ChildrenCenter: Story = {
     </Center>
   ),
 };
+
+export const AsSection: Story = {
+  render: () => (
+    <Center as="section" maxWidth="400px">
+      <h2>Heading</h2>
+
+      <p>body</p>
+    </Center>
+  ),
+};

--- a/src/stories/Flex.stories.tsx
+++ b/src/stories/Flex.stories.tsx
@@ -159,3 +159,14 @@ export const Wrap: Story = {
     </div>
   ),
 };
+
+export const AsSection: Story = {
+  render: () => (
+    <Flex as="section" spacing="md" alignItems="center">
+      <h1>Heading</h1>
+      <p>Section</p>
+      <p>Section</p>
+      <p>Section</p>
+    </Flex>
+  ),
+};

--- a/src/stories/Text.stories.tsx
+++ b/src/stories/Text.stories.tsx
@@ -1,5 +1,5 @@
 import { Meta, StoryObj } from '@storybook/react';
-import { Text, Stack } from '../';
+import { Text, Flex, Stack } from '../';
 
 export default {
   component: Text,
@@ -19,7 +19,7 @@ export const Default: Story = {
 
 export const Color: Story = {
   render: () => (
-    <Stack spacing="md" direction="row">
+    <Flex spacing="md">
       <Text color="main">main</Text>
       <Text color="sub">sub</Text>
       <Text color="link">link</Text>
@@ -31,7 +31,7 @@ export const Color: Story = {
       <span style={{ background: 'black', padding: '0 0.5em' }}>
         <Text color="white">white</Text>
       </span>
-    </Stack>
+    </Flex>
   ),
   args: defaultArgs,
 };
@@ -41,7 +41,7 @@ export const Heading: Story = {
     const headingText = '近くの医療機関から調べる';
 
     return (
-      <Stack spacing="md" direction="row" alignItems="center">
+      <Flex spacing="md" alignItems="center">
         <Text bold type="heading" size="xs">
           xs
           <br />
@@ -67,7 +67,7 @@ export const Heading: Story = {
           <br />
           {`${headingText}`}
         </Text>
-      </Stack>
+      </Flex>
     );
   },
   args: defaultArgs,
@@ -83,7 +83,7 @@ export const Body: Story = {
         <div>
           <dt>Default Leading</dt>
           <dd>
-            <Stack spacing="md" direction="row" alignItems="center">
+            <Flex spacing="md" alignItems="center">
               <Text type="body" size="sm">
                 sm
                 <br />
@@ -99,14 +99,14 @@ export const Body: Story = {
                 <br />
                 {`${bodyText}`}
               </Text>
-            </Stack>
+            </Flex>
           </dd>
         </div>
 
         <div>
           <dt>Narrow Leading</dt>
           <dd>
-            <Stack spacing="md" direction="row" alignItems="center">
+            <Flex spacing="md" alignItems="center">
               <Text leading="narrow" type="body" size="sm">
                 sm
                 <br />
@@ -122,14 +122,14 @@ export const Body: Story = {
                 <br />
                 {`${bodyText}`}
               </Text>
-            </Stack>
+            </Flex>
           </dd>
         </div>
 
         <div>
           <dt>Tight Leading</dt>
           <dd>
-            <Stack spacing="md" direction="row" alignItems="center">
+            <Flex spacing="md" alignItems="center">
               <Text leading="tight" type="body" size="sm">
                 sm
                 <br />
@@ -145,7 +145,7 @@ export const Body: Story = {
                 <br />
                 {`${bodyText}`}
               </Text>
-            </Stack>
+            </Flex>
           </dd>
         </div>
       </Stack>
@@ -164,7 +164,7 @@ export const Note: Story = {
         <div>
           <dt>Default Leading</dt>
           <dd>
-            <Stack spacing="md" direction="row" alignItems="center">
+            <Flex spacing="md" alignItems="center">
               <Text type="note" size="sm">
                 sm
                 <br />
@@ -180,14 +180,14 @@ export const Note: Story = {
                 <br />
                 {`${noteText}`}
               </Text>
-            </Stack>
+            </Flex>
           </dd>
         </div>
 
         <div>
           <dt>Narrow Leading</dt>
           <dd>
-            <Stack spacing="md" direction="row" alignItems="center">
+            <Flex spacing="md" alignItems="center">
               <Text leading="narrow" type="note" size="sm">
                 sm
                 <br />
@@ -203,13 +203,13 @@ export const Note: Story = {
                 <br />
                 {`${noteText}`}
               </Text>
-            </Stack>
+            </Flex>
           </dd>
         </div>
         <div>
           <dt>Tight Leading</dt>
           <dd>
-            <Stack spacing="md" direction="row" alignItems="center">
+            <Flex spacing="md" alignItems="center">
               <Text leading="tight" type="note" size="sm">
                 sm
                 <br />
@@ -225,7 +225,7 @@ export const Note: Story = {
                 <br />
                 {`${noteText}`}
               </Text>
-            </Stack>
+            </Flex>
           </dd>
         </div>
       </Stack>
@@ -239,7 +239,7 @@ export const Button: Story = {
     const buttonText = '同意して症状から調べる';
 
     return (
-      <Stack spacing="md" direction="row" alignItems="center">
+      <Flex spacing="md" alignItems="center">
         <Text type="button" size="sm">
           sm
           <br />
@@ -255,7 +255,7 @@ export const Button: Story = {
           <br />
           {`${buttonText}`}
         </Text>
-      </Stack>
+      </Flex>
     );
   },
   args: defaultArgs,
@@ -266,7 +266,7 @@ export const Tag: Story = {
     const tagText = '循環器内科';
 
     return (
-      <Stack spacing="md" direction="row" alignItems="center">
+      <Flex spacing="md" alignItems="center">
         <Text type="tag" size="sm">
           sm
           <br />
@@ -282,7 +282,7 @@ export const Tag: Story = {
           <br />
           {`${tagText}`}
         </Text>
-      </Stack>
+      </Flex>
     );
   },
   args: defaultArgs,
@@ -292,6 +292,17 @@ export const WithId: Story = {
   render: () => (
     <Text id="text-id" type="heading" size="xl" as="h2" color="primary" bold>
       Dummy Text
+    </Text>
+  ),
+};
+
+export const TextInText: Story = {
+  render: () => (
+    <Text type="note" size="lg">
+      <Text as="span" type="note" size="lg" color="alert" bold>
+        Alert:
+      </Text>{' '}
+      Please fill in all fields
     </Text>
   ),
 };

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -1,1 +1,3 @@
 export type AllOrNone<T> = T | Partial<Record<keyof T, undefined>>;
+
+export type HTMLTagname = keyof HTMLElementTagNameMap;


### PR DESCRIPTION
# Overview

- horizontal layouts should use Flex
- delete `direction` prop from Stack
- With this, `as` prop was needed for Flex in Story, it was added.
  - And while we're at it, add `as` prop to the layout component