### PR TITLE
Disallow console

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -56,5 +56,6 @@ module.exports = {
     ],
     'unused-imports/no-unused-imports': 'error',
     'import/no-unresolved': 'off',
+    'no-console': 'error',
   },
 };


### PR DESCRIPTION
# Overview

Because `console.log` used to get mixed up and We spent some time trying to get rid of it.