### PR TITLE
feat(Button): 🎸 Add loading status

### DIFF
--- a/src/components/Button/Button.module.css
+++ b/src/components/Button/Button.module.css
@@ -58,6 +58,11 @@
   border-color: var(--border-color-disabled);
 }
 
+.loading {
+  pointer-events: none;
+  cursor: wait;
+}
+
 /* Variant */
 
 .primary {

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -3,6 +3,7 @@
 import { clsx } from 'clsx';
 import { forwardRef } from 'react';
 import styles from './Button.module.css';
+import { CircularProgress } from './CircularProgress';
 import { VariantIcon } from './VariantIcon';
 import type { ButtonProps } from './ButtonTypes';
 
@@ -17,11 +18,13 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
       fixedIcon: _fixedIcon,
       suffixIcon: _suffixIcon,
       type = 'button',
+      disabled = false,
+      loading = false,
       ...props
     },
     ref,
   ) => {
-    const icon = _icon === 'default' ? <VariantIcon variant={variant} /> : _icon;
+    const icon = loading ? <CircularProgress /> : _icon === 'default' ? <VariantIcon variant={variant} /> : _icon;
     const fixedIcon = _fixedIcon === 'default' ? <VariantIcon variant={variant} /> : _fixedIcon;
     const suffixIcon = _suffixIcon === 'default' ? <VariantIcon variant={variant} /> : _suffixIcon;
     const cls = clsx({
@@ -29,10 +32,12 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
       [styles[variant]]: true,
       [styles[size]]: true,
       [styles.block]: block,
-      [styles.disabled]: !!props.disabled,
+      [styles.disabled]: disabled,
+      [styles.loading]: loading,
     });
+
     return (
-      <button type={type} className={cls} ref={ref} {...props}>
+      <button type={type} className={cls} ref={ref} disabled={disabled || loading} {...props}>
         {fixedIcon && <span className={styles.fixedIcon}>{fixedIcon}</span>}
         <span className={styles.label}>
           {icon && <span className={styles.icon}>{icon}</span>}

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -20,6 +20,7 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
       type = 'button',
       disabled = false,
       loading = false,
+      onClick,
       ...props
     },
     ref,
@@ -36,8 +37,25 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
       [styles.loading]: loading,
     });
 
+    const handleClick = (e: React.MouseEvent<HTMLButtonElement>) => {
+      if (loading) {
+        e.preventDefault();
+        return;
+      }
+
+      onClick?.(e);
+    };
+
     return (
-      <button type={type} className={cls} ref={ref} disabled={disabled || loading} {...props}>
+      <button
+        type={type}
+        className={cls}
+        ref={ref}
+        disabled={disabled}
+        aria-disabled={loading}
+        onClick={handleClick}
+        {...props}
+      >
         {fixedIcon && <span className={styles.fixedIcon}>{fixedIcon}</span>}
         <span className={styles.label}>
           {icon && <span className={styles.icon}>{icon}</span>}

--- a/src/components/Button/ButtonTypes.ts
+++ b/src/components/Button/ButtonTypes.ts
@@ -37,6 +37,10 @@ export type BaseProps = {
    * 後方配置のアイコン
    */
   suffixIcon?: 'default' | ReactNode;
+  /**
+   * ローディング状態を示す
+   */
+  loading?: boolean;
 };
 
 export type OnlyButtonProps = {

--- a/src/components/Button/ButtonTypes.ts
+++ b/src/components/Button/ButtonTypes.ts
@@ -37,10 +37,6 @@ export type BaseProps = {
    * 後方配置のアイコン
    */
   suffixIcon?: 'default' | ReactNode;
-  /**
-   * ローディング状態を示す
-   */
-  loading?: boolean;
 };
 
 export type OnlyButtonProps = {
@@ -54,6 +50,10 @@ export type OnlyButtonProps = {
    * @default false
    */
   disabled?: boolean;
+  /**
+   * ローディング状態を示す
+   */
+  loading?: boolean;
 };
 
 export type OnlyLinkButtonProps = {

--- a/src/components/Button/CircularProgress.module.css
+++ b/src/components/Button/CircularProgress.module.css
@@ -1,0 +1,38 @@
+.root {
+  display: flex;
+  animation: spin 1.4s linear infinite;
+  transform-origin: center;
+}
+
+.circle {
+  stroke: currentcolor;
+  animation: circular-progress 1.4s ease-in-out infinite;
+  transform-origin: center;
+}
+
+@keyframes spin {
+  0% {
+    transform: rotate(0deg);
+  }
+
+  100% {
+    transform: rotate(360deg);
+  }
+}
+
+@keyframes circular-progress {
+  0% {
+    stroke-dasharray: 1px, 200px;
+    stroke-dashoffset: 0;
+  }
+
+  50% {
+    stroke-dasharray: 100px, 200px;
+    stroke-dashoffset: -16px;
+  }
+
+  100% {
+    stroke-dasharray: 100px, 200px;
+    stroke-dashoffset: -124px;
+  }
+}

--- a/src/components/Button/CircularProgress.tsx
+++ b/src/components/Button/CircularProgress.tsx
@@ -7,7 +7,11 @@ const THICKNESS = 3.6;
 export const CircularProgress: FC = ({ ...props }) => {
   return (
     <span role="progressbar" className={styles.root} {...props}>
-      <svg role="img" aria-label="読み込み中" viewBox={`${CIRCLE_SIZE / 2} ${CIRCLE_SIZE / 2} ${CIRCLE_SIZE} ${CIRCLE_SIZE}`}>
+      <svg
+        role="img"
+        aria-label="読み込み中"
+        viewBox={`${CIRCLE_SIZE / 2} ${CIRCLE_SIZE / 2} ${CIRCLE_SIZE} ${CIRCLE_SIZE}`}
+      >
         <circle
           className={styles.circle}
           cx={CIRCLE_SIZE}

--- a/src/components/Button/CircularProgress.tsx
+++ b/src/components/Button/CircularProgress.tsx
@@ -16,7 +16,6 @@ export const CircularProgress: FC = ({ ...props }) => {
           fill="none"
           strokeWidth={THICKNESS}
         />
-        s
       </svg>
     </span>
   );

--- a/src/components/Button/CircularProgress.tsx
+++ b/src/components/Button/CircularProgress.tsx
@@ -1,0 +1,23 @@
+import { FC } from 'react';
+import styles from './CircularProgress.module.css';
+
+const CIRCLE_SIZE = 44;
+const THICKNESS = 3.6;
+
+export const CircularProgress: FC = ({ ...props }) => {
+  return (
+    <span role="progressbar" className={styles.root} {...props}>
+      <svg viewBox={`${CIRCLE_SIZE / 2} ${CIRCLE_SIZE / 2} ${CIRCLE_SIZE} ${CIRCLE_SIZE}`}>
+        <circle
+          className={styles.circle}
+          cx={CIRCLE_SIZE}
+          cy={CIRCLE_SIZE}
+          r={(CIRCLE_SIZE - THICKNESS) / 2}
+          fill="none"
+          strokeWidth={THICKNESS}
+        />
+        s
+      </svg>
+    </span>
+  );
+};

--- a/src/components/Button/CircularProgress.tsx
+++ b/src/components/Button/CircularProgress.tsx
@@ -7,7 +7,7 @@ const THICKNESS = 3.6;
 export const CircularProgress: FC = ({ ...props }) => {
   return (
     <span role="progressbar" className={styles.root} {...props}>
-      <svg viewBox={`${CIRCLE_SIZE / 2} ${CIRCLE_SIZE / 2} ${CIRCLE_SIZE} ${CIRCLE_SIZE}`}>
+      <svg role="img" aria-label="読み込み中" viewBox={`${CIRCLE_SIZE / 2} ${CIRCLE_SIZE / 2} ${CIRCLE_SIZE} ${CIRCLE_SIZE}`}>
         <circle
           className={styles.circle}
           cx={CIRCLE_SIZE}

--- a/src/stories/Button.stories.tsx
+++ b/src/stories/Button.stories.tsx
@@ -130,3 +130,16 @@ export const Disabled: Story = {
   ),
   args: defaultArgs,
 };
+
+export const Loading: Story = {
+  render: () => (
+    <div style={{ display: 'flex', flexDirection: 'row', alignItems: 'flex-start', gap: '32px' }}>
+      <Button {...defaultArgs} loading />
+      <Button {...defaultArgs} variant="secondary" loading />
+      <Button {...defaultArgs} variant="accent" loading />
+      <Button {...defaultArgs} variant="alert" loading />
+      <Button {...defaultArgs} variant="text" loading />
+      <Button {...defaultArgs} variant="textAlert" loading />
+    </div>
+  ),
+};


### PR DESCRIPTION
Added loading status for Button component, so that we can explicitly feed back after user action.
I added CircularProgress component as an internal component of the Button, because I don't see any other usecase in the ubie-ui repo at least for now, and I didn't want to specify width and height so the same style for prefix icon should be applied.

In the application, only places I noticed the circular progress is used was loggin page using `Chakura-ui`, so made new one. Maybe that should be replaced with custom loading icon ... ?



https://github.com/ubie-oss/ubie-ui/assets/33568829/0bfeb705-82f8-45ad-b326-b72d5847dfbf

