### PR TITLE
Add text props to box

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -57,5 +57,14 @@ module.exports = {
     'unused-imports/no-unused-imports': 'error',
     'import/no-unresolved': 'off',
     'no-console': 'error',
+    "@typescript-eslint/no-unused-vars": [
+      "error",
+      {
+        "argsIgnorePattern": "_",
+        "varsIgnorePattern": "_",
+        "caughtErrorsIgnorePattern": "_",
+        "destructuredArrayIgnorePattern": "_"
+      }
+    ]
   },
 };

--- a/src/components/Box/Box.module.css
+++ b/src/components/Box/Box.module.css
@@ -61,3 +61,7 @@
 .box.textBold {
   font-weight: bold;
 }
+
+.box.textNormal {
+  font-weight: normal;
+}

--- a/src/components/Box/Box.module.css
+++ b/src/components/Box/Box.module.css
@@ -4,6 +4,10 @@
   padding: var(--padding-top) var(--padding-right) var(--padding-bottom) var(--padding-left);
   margin: var(--margin-top) var(--margin-right) var(--margin-bottom) var(--margin-left);
   border-radius: var(--radius);
+  font-size: var(--text-size);
+  color: var(--text-color);
+  line-height: var(--text-leading);
+  font-weight: var(--text-bold);
 }
 
 .box.backgroundColorPrimary {
@@ -52,4 +56,8 @@
 
 .box.widthFull {
   width: 100%;
+}
+
+.box.textBold {
+  font-weight: bold;
 }

--- a/src/components/Box/Box.tsx
+++ b/src/components/Box/Box.tsx
@@ -3,10 +3,28 @@
 import clsx from 'clsx';
 import styles from './Box.module.css';
 import {} from '../../types/style';
-import { paddingVariables, marginVariables, radiusVariables } from '../../utils/style';
+import {
+  paddingVariables,
+  marginVariables,
+  radiusVariables,
+  cssFontSizeToken,
+  cssLeadingToken,
+  colorVariable,
+} from '../../utils/style';
 import { HTMLTagname } from '../../utils/types';
-import type { PaddingProps, MarginProps, RadiusProp, BackgroundColor } from '../../types/style';
-import type { FC, PropsWithChildren } from 'react';
+import type {
+  PaddingProps,
+  MarginProps,
+  RadiusProp,
+  BackgroundColor,
+  TextType,
+  TextColor,
+  BodyFontSize,
+  BodyLeading,
+  NoteFontSize,
+  NoteLeading,
+} from '../../types/style';
+import type { CSSProperties, FC, PropsWithChildren } from 'react';
 
 type Props = {
   /**
@@ -26,14 +44,97 @@ type Props = {
    * 幅を指定。他のスタイルの影響を受け、幅が100%とならない場合にのみ使用
    */
   width?: 'full';
+  /**
+   * 内包するテキストをボールドとするかどうか
+   */
+  textBold?: boolean;
 } & PaddingProps &
   MarginProps &
-  RadiusProp;
+  RadiusProp & {
+    /**
+     * テキストの種類
+     */
+    textType?: undefined;
+    /**
+     * フォントサイズの抽象値。合わせてtextTypeの指定が必須
+     */
+    textSize?: unknown;
+    /**
+     * 行送りの抽象値（`line-height`）。合わせてtextTypeとtextSizeの指定が必須
+     */
+    textLeading?: unknown;
+    /**
+     * 文字色の抽象値
+     */
+    textColor?: TextColor;
+  };
+
+type PropsWithBody = Omit<Props, 'textType' | 'textSize' | 'textLeading'> & {
+  textType: Extract<TextType, 'body'>;
+  textSize?: BodyFontSize;
+  textLeading?: BodyLeading;
+  textColor?: TextColor;
+};
+
+type PropsWithNote = Omit<Props, 'textType' | 'textSize' | 'textLeading'> & {
+  textType: Extract<TextType, 'note'>;
+  textSize?: NoteFontSize;
+  textLeading?: NoteLeading;
+  textColor?: TextColor;
+};
+
+/**
+ * If type is not specified, an empty object is returned because it is unknown how it is to be styled, i.e. it is not styled.
+ * If type is specified but size or leading is not, specify default values (md or default.)
+ */
+export const textStyleVariables = ({
+  type,
+  size: _size,
+  leading: _leading,
+}:
+  | {
+      type: undefined;
+      size: unknown;
+      leading: unknown;
+    }
+  | {
+      type: Extract<TextType, 'body'>;
+      size: BodyFontSize | undefined;
+      leading: BodyLeading | undefined;
+    }
+  | {
+      type: Extract<TextType, 'note'>;
+      size: NoteFontSize | undefined;
+      leading: NoteLeading | undefined;
+    }): CSSProperties => {
+  if (type == null) return {};
+
+  const size = type != null && _size == null ? 'md' : _size;
+  const leading = type != null && _leading == null ? 'default' : _leading;
+
+  switch (type) {
+    case 'body':
+      return {
+        '--text-size': size ? cssFontSizeToken({ type, size }) : 'inherit',
+        '--text-leading': leading ? cssLeadingToken({ type, size: size || 'md', leading }) : 'inherit',
+      } as CSSProperties;
+    case 'note':
+      return {
+        '--text-size': size ? cssFontSizeToken({ type, size }) : 'inherit',
+        '--text-leading': leading ? cssLeadingToken({ type, size: size || 'md', leading }) : 'inherit',
+      } as CSSProperties;
+    default:
+      // eslint-disable-next-line no-case-declarations
+      const _: never = type;
+  }
+
+  return {};
+};
 
 const capitalize = (str: string) => str.charAt(0).toUpperCase() + str.slice(1);
 
-export const Box: FC<PropsWithChildren<Props>> = ({
-  as: BoxCopmonent = 'div',
+export const Box: FC<PropsWithChildren<Props | PropsWithBody | PropsWithNote>> = ({
+  as: BoxComponent = 'div',
   children,
   pt,
   pr,
@@ -47,14 +148,28 @@ export const Box: FC<PropsWithChildren<Props>> = ({
   backgroundColor,
   border,
   width,
+  textType,
+  textSize,
+  textLeading,
+  textColor,
+  textBold,
 }) => {
+  let _textVariables: CSSProperties = {};
+
+  if (textType === 'body') {
+    _textVariables = textStyleVariables({ type: textType, size: textSize, leading: textLeading });
+  } else if (textType === 'note') {
+    _textVariables = textStyleVariables({ type: textType, size: textSize, leading: textLeading });
+  }
+
   return (
-    <BoxCopmonent
+    <BoxComponent
       className={clsx([
         styles.box,
         backgroundColor && styles[`backgroundColor${capitalize(backgroundColor)}`],
         border && styles[`border${capitalize(border)}`],
         width && styles.widthFull,
+        textBold && styles.textBold,
       ])}
       style={{
         ...paddingVariables({
@@ -70,9 +185,11 @@ export const Box: FC<PropsWithChildren<Props>> = ({
           ml,
         }),
         ...radiusVariables(radius),
+        ..._textVariables,
+        ...colorVariable(textColor),
       }}
     >
       {children}
-    </BoxCopmonent>
+    </BoxComponent>
   );
 };

--- a/src/components/Box/Box.tsx
+++ b/src/components/Box/Box.tsx
@@ -62,13 +62,13 @@ type PropsWithoutText = BaseProps & {
    */
   textType?: undefined;
   /**
-   * フォントサイズの抽象値。合わせてtextTypeの指定が必須
+   * フォントサイズの抽象値。合わせてtextTypeの指定が必須で、typeに応じた値が指定可能
    */
-  textSize?: unknown;
+  textSize?: never;
   /**
-   * 行送りの抽象値（`line-height`）。合わせてtextTypeとtextSizeの指定が必須
+   * 行送りの抽象値（`line-height`）。合わせてtextTypeとtextSizeの指定が必須で、typeに応じた値が指定可能
    */
-  textLeading?: unknown;
+  textLeading?: never;
 };
 
 type PropsWithTextBody = BaseProps & {
@@ -77,11 +77,11 @@ type PropsWithTextBody = BaseProps & {
    */
   textType: Extract<TextType, 'body'>;
   /**
-   * フォントサイズの抽象値。合わせてtextTypeの指定が必須
+   * フォントサイズの抽象値。合わせてtextTypeの指定が必須で、typeに応じた値が指定可能
    */
   textSize?: BodyFontSize;
   /**
-   * 行送りの抽象値（`line-height`）。合わせてtextTypeとtextSizeの指定が必須
+   * 行送りの抽象値（`line-height`）。合わせてtextTypeとtextSizeの指定が必須で、typeに応じた値が指定可能
    */
   textLeading?: BodyLeading;
 };
@@ -92,11 +92,11 @@ type PropsWithTextNote = BaseProps & {
    */
   textType: Extract<TextType, 'note'>;
   /**
-   * フォントサイズの抽象値。合わせてtextTypeの指定が必須
+   * フォントサイズの抽象値。合わせてtextTypeの指定が必須で、typeに応じた値が指定可能
    */
   textSize?: NoteFontSize;
   /**
-   * 行送りの抽象値（`line-height`）。合わせてtextTypeとtextSizeの指定が必須
+   * 行送りの抽象値（`line-height`）。合わせてtextTypeとtextSizeの指定が必須で、typeに応じた値が指定可能
    */
   textLeading?: NoteLeading;
 };

--- a/src/components/Box/Box.tsx
+++ b/src/components/Box/Box.tsx
@@ -26,7 +26,7 @@ import type {
 } from '../../types/style';
 import type { CSSProperties, FC, PropsWithChildren } from 'react';
 
-type Props = {
+type BaseProps = {
   /**
    * レンダリングされるHTML要素
    * @default div
@@ -48,39 +48,57 @@ type Props = {
    * 内包するテキストをボールドとするかどうか
    */
   textBold?: boolean;
+  /**
+   * 文字色の抽象値。のかのtext系Propとは独立して指定可能
+   */
+  textColor?: TextColor;
 } & PaddingProps &
   MarginProps &
-  RadiusProp & {
-    /**
-     * テキストの種類
-     */
-    textType?: undefined;
-    /**
-     * フォントサイズの抽象値。合わせてtextTypeの指定が必須
-     */
-    textSize?: unknown;
-    /**
-     * 行送りの抽象値（`line-height`）。合わせてtextTypeとtextSizeの指定が必須
-     */
-    textLeading?: unknown;
-    /**
-     * 文字色の抽象値
-     */
-    textColor?: TextColor;
-  };
+  RadiusProp;
 
-type PropsWithBody = Omit<Props, 'textType' | 'textSize' | 'textLeading'> & {
-  textType: Extract<TextType, 'body'>;
-  textSize?: BodyFontSize;
-  textLeading?: BodyLeading;
-  textColor?: TextColor;
+type PropsWithoutText = BaseProps & {
+  /**
+   * テキストの種類
+   */
+  textType?: undefined;
+  /**
+   * フォントサイズの抽象値。合わせてtextTypeの指定が必須
+   */
+  textSize?: unknown;
+  /**
+   * 行送りの抽象値（`line-height`）。合わせてtextTypeとtextSizeの指定が必須
+   */
+  textLeading?: unknown;
 };
 
-type PropsWithNote = Omit<Props, 'textType' | 'textSize' | 'textLeading'> & {
+type PropsWithTextBody = BaseProps & {
+  /**
+   * テキストの種類
+   */
+  textType: Extract<TextType, 'body'>;
+  /**
+   * フォントサイズの抽象値。合わせてtextTypeの指定が必須
+   */
+  textSize?: BodyFontSize;
+  /**
+   * 行送りの抽象値（`line-height`）。合わせてtextTypeとtextSizeの指定が必須
+   */
+  textLeading?: BodyLeading;
+};
+
+type PropsWithTextNote = BaseProps & {
+  /**
+   * テキストの種類
+   */
   textType: Extract<TextType, 'note'>;
+  /**
+   * フォントサイズの抽象値。合わせてtextTypeの指定が必須
+   */
   textSize?: NoteFontSize;
+  /**
+   * 行送りの抽象値（`line-height`）。合わせてtextTypeとtextSizeの指定が必須
+   */
   textLeading?: NoteLeading;
-  textColor?: TextColor;
 };
 
 /**
@@ -94,8 +112,8 @@ export const textStyleVariables = ({
 }:
   | {
       type: undefined;
-      size: unknown;
-      leading: unknown;
+      size: never;
+      leading: never;
     }
   | {
       type: Extract<TextType, 'body'>;
@@ -133,7 +151,7 @@ export const textStyleVariables = ({
 
 const capitalize = (str: string) => str.charAt(0).toUpperCase() + str.slice(1);
 
-export const Box: FC<PropsWithChildren<Props | PropsWithBody | PropsWithNote>> = ({
+export const Box: FC<PropsWithChildren<PropsWithoutText | PropsWithTextBody | PropsWithTextNote>> = ({
   as: BoxComponent = 'div',
   children,
   pt,

--- a/src/components/Box/Box.tsx
+++ b/src/components/Box/Box.tsx
@@ -45,7 +45,7 @@ type BaseProps = {
    */
   width?: 'full';
   /**
-   * 内包するテキストをボールドとするかどうか
+   * 内包するテキストをボールドとするかどうか。指定しない場合は親要素のスタイルを継承、trueでボールド、falseとするとnormal
    */
   textBold?: boolean;
   /**
@@ -188,6 +188,7 @@ export const Box: FC<PropsWithChildren<PropsWithoutText | PropsWithTextBody | Pr
         border && styles[`border${capitalize(border)}`],
         width && styles.widthFull,
         textBold && styles.textBold,
+        textBold === false && styles.textNormal,
       ])}
       style={{
         ...paddingVariables({

--- a/src/components/Box/Box.tsx
+++ b/src/components/Box/Box.tsx
@@ -58,45 +58,45 @@ type BaseProps = {
 
 type PropsWithoutText = BaseProps & {
   /**
-   * テキストの種類
+   * 配下に含むテキストの種類
    */
   textType?: undefined;
   /**
-   * フォントサイズの抽象値。合わせてtextTypeの指定が必須で、typeに応じた値が指定可能
+   * 配下に含むテキストのフォントサイズの抽象値。合わせてtextTypeの指定が必須で、typeに応じた値が指定可能
    */
   textSize?: never;
   /**
-   * 行送りの抽象値（`line-height`）。合わせてtextTypeとtextSizeの指定が必須で、typeに応じた値が指定可能
+   * 配下に含むテキストの行送りの抽象値（`line-height`）。合わせてtextTypeとtextSizeの指定が必須で、typeに応じた値が指定可能
    */
   textLeading?: never;
 };
 
 type PropsWithTextBody = BaseProps & {
   /**
-   * テキストの種類
+   * 配下に含むテキストの種類
    */
   textType: Extract<TextType, 'body'>;
   /**
-   * フォントサイズの抽象値。合わせてtextTypeの指定が必須で、typeに応じた値が指定可能
+   * 配下に含むテキストのフォントサイズの抽象値。合わせてtextTypeの指定が必須で、typeに応じた値が指定可能
    */
   textSize?: BodyFontSize;
   /**
-   * 行送りの抽象値（`line-height`）。合わせてtextTypeとtextSizeの指定が必須で、typeに応じた値が指定可能
+   * 配下に含むテキストの行送りの抽象値（`line-height`）。合わせてtextTypeとtextSizeの指定が必須で、typeに応じた値が指定可能
    */
   textLeading?: BodyLeading;
 };
 
 type PropsWithTextNote = BaseProps & {
   /**
-   * テキストの種類
+   * 配下に含むテキストの種類
    */
   textType: Extract<TextType, 'note'>;
   /**
-   * フォントサイズの抽象値。合わせてtextTypeの指定が必須で、typeに応じた値が指定可能
+   * 配下に含むテキストのフォントサイズの抽象値。合わせてtextTypeの指定が必須で、typeに応じた値が指定可能
    */
   textSize?: NoteFontSize;
   /**
-   * 行送りの抽象値（`line-height`）。合わせてtextTypeとtextSizeの指定が必須で、typeに応じた値が指定可能
+   * 配下に含むテキストの行送りの抽象値（`line-height`）。合わせてtextTypeとtextSizeの指定が必須で、typeに応じた値が指定可能
    */
   textLeading?: NoteLeading;
 };

--- a/src/components/Text/Text.tsx
+++ b/src/components/Text/Text.tsx
@@ -3,7 +3,19 @@
 import { clsx } from 'clsx';
 import { FC, ReactNode } from 'react';
 import styles from './Text.module.css';
-import { TextColor } from '../../types/style';
+import {
+  TextColor,
+  BodyFontSize,
+  BodyLeading,
+  HeadingFontSize,
+  HeadingLeading,
+  NoteFontSize,
+  NoteLeading,
+  ButtonFontSize,
+  ButtonLeading,
+  TagFontSize,
+  TagLeading,
+} from '../../types/style';
 import { HTMLTagname } from '../../utils/types';
 
 type BaseProps = {
@@ -32,8 +44,6 @@ type BaseProps = {
   id?: string;
 };
 
-type BodyFontSize = 'sm' | 'md' | 'lg';
-type BodyLeading = 'default' | 'narrow' | 'tight';
 type BodyProps = BaseProps & {
   /**
    * テキストの種類
@@ -51,7 +61,6 @@ type BodyProps = BaseProps & {
   leading?: BodyLeading;
 };
 
-type HeadingFontSize = 'xs' | 'sm' | 'md' | 'lg' | 'xl';
 type HeadingProps = BaseProps & {
   /**
    * テキストの種類
@@ -65,11 +74,9 @@ type HeadingProps = BaseProps & {
    * 行送りの抽象値（`line-height`）
    * @default default
    */
-  leading?: 'default';
+  leading?: HeadingLeading;
 };
 
-type NoteFontSize = 'sm' | 'md' | 'lg';
-type NoteLeading = 'default' | 'narrow' | 'tight';
 type NoteProps = BaseProps & {
   /**
    * テキストの種類
@@ -86,7 +93,6 @@ type NoteProps = BaseProps & {
   leading?: NoteLeading;
 };
 
-type ButtonFontSize = 'sm' | 'md' | 'lg';
 type ButtonProps = BaseProps & {
   /**
    * テキストの種類
@@ -100,10 +106,9 @@ type ButtonProps = BaseProps & {
    * 行送りの抽象値（`line-height`）
    * @default default
    */
-  leading?: 'default';
+  leading?: ButtonLeading;
 };
 
-type TagFontSize = 'sm' | 'md' | 'lg';
 type TagProps = BaseProps & {
   /**
    * テキストの種類
@@ -117,7 +122,7 @@ type TagProps = BaseProps & {
    * 行送りの抽象値（`line-height`）
    * @default default
    */
-  leading?: 'default';
+  leading?: TagLeading;
 };
 
 type TextProps = BodyProps | HeadingProps | NoteProps | ButtonProps | TagProps;

--- a/src/stories/Box.stories.tsx
+++ b/src/stories/Box.stories.tsx
@@ -137,6 +137,10 @@ export const Border: Story = {
       <Box {...defaultArgs} backgroundColor="white" border="gray">
         Border Gray
       </Box>
+
+      <Box {...defaultArgs} backgroundColor="white" border="gray">
+        Border Gray
+      </Box>
       <Box mt="md" {...defaultArgs} backgroundColor="white" border="grayThick">
         Border Gray Thick
       </Box>
@@ -172,5 +176,119 @@ export const AsSection: Story = {
 
       <p>body</p>
     </Box>
+  ),
+};
+
+export const TextVariations: Story = {
+  render: () => (
+    <div>
+      <Box
+        {...defaultArgs}
+        backgroundColor="gray"
+        textColor="primary"
+        textBold
+        textType="body"
+        textSize="lg"
+        textLeading="narrow"
+      >
+        <p>Text Bold</p>
+      </Box>
+
+      <Box {...defaultArgs} mt="lg" backgroundColor="gray" textColor="main" textBold>
+        <p>Text Bold</p>
+      </Box>
+
+      <Box {...defaultArgs} backgroundColor="gray" mt="xl" textColor="main">
+        <p>Color Main</p>
+      </Box>
+      <Box {...defaultArgs} backgroundColor="gray" mt="md" textColor="sub">
+        <p>Color Sub</p>
+      </Box>
+      <Box {...defaultArgs} backgroundColor="gray" mt="md" textColor="link">
+        <p>Color Main</p>
+      </Box>
+      <Box {...defaultArgs} backgroundColor="gray" mt="md" textColor="linkSub">
+        <p>Color Link Sub</p>
+      </Box>
+      <Box {...defaultArgs} backgroundColor="gray" mt="md" textColor="disabled">
+        <p>Color Disabled</p>
+      </Box>
+      <Box {...defaultArgs} backgroundColor="gray" mt="md" textColor="primary">
+        <p>Color Primary</p>
+      </Box>
+      <Box {...defaultArgs} backgroundColor="gray" mt="md" textColor="accent">
+        <p>Color Accent</p>
+      </Box>
+      <Box {...defaultArgs} backgroundColor="gray" mt="md" textColor="alert">
+        <p>Color Alert</p>
+      </Box>
+      <Box {...defaultArgs} mt="xl" textType="body">
+        <p>Body size & leading default value</p>
+      </Box>
+
+      <Box {...defaultArgs} mt="xl" textType="body" textSize="sm" textLeading="default">
+        <p>Body Small Default</p>
+      </Box>
+      <Box {...defaultArgs} mt="md" textType="body" textSize="sm" textLeading="narrow">
+        <p>Body Small Narrow</p>
+      </Box>
+      <Box {...defaultArgs} mt="md" textType="body" textSize="sm" textLeading="tight">
+        <p>Body Small Tight</p>
+      </Box>
+
+      <Box {...defaultArgs} mt="xl" textType="body" textSize="md" textLeading="default">
+        <p>Body Medium Default</p>
+      </Box>
+      <Box {...defaultArgs} mt="md" textType="body" textSize="md" textLeading="narrow">
+        <p>Body Medium Narrow</p>
+      </Box>
+      <Box {...defaultArgs} mt="md" textType="body" textSize="md" textLeading="tight">
+        <p>Body Medium Tight</p>
+      </Box>
+
+      <Box {...defaultArgs} mt="xl" textType="body" textSize="lg" textLeading="default">
+        <p>Body Large Default</p>
+      </Box>
+      <Box {...defaultArgs} mt="md" textType="body" textSize="lg" textLeading="narrow">
+        <p>Body Large Narrow</p>
+      </Box>
+      <Box {...defaultArgs} mt="md" textType="body" textSize="lg" textLeading="tight">
+        <p>Body Large Tight</p>
+      </Box>
+
+      <Box {...defaultArgs} mt="xl" textType="note">
+        <p>Note size & leading default value</p>
+      </Box>
+
+      <Box {...defaultArgs} mt="xl" textType="note" textSize="sm" textLeading="default">
+        <p>Note Small Default</p>
+      </Box>
+      <Box {...defaultArgs} mt="md" textType="note" textSize="sm" textLeading="narrow">
+        <p>Note Small Narrow</p>
+      </Box>
+      <Box {...defaultArgs} mt="md" textType="note" textSize="sm" textLeading="tight">
+        <p>Note Small Tight</p>
+      </Box>
+
+      <Box {...defaultArgs} mt="xl" textType="note" textSize="md" textLeading="default">
+        <p>Note Medium Default</p>
+      </Box>
+      <Box {...defaultArgs} mt="md" textType="note" textSize="md" textLeading="narrow">
+        <p>Note Medium Narrow</p>
+      </Box>
+      <Box {...defaultArgs} mt="md" textType="note" textSize="md" textLeading="tight">
+        <p>Note Medium Tight</p>
+      </Box>
+
+      <Box {...defaultArgs} mt="xl" textType="note" textSize="lg" textLeading="default">
+        <p>Note Large Default</p>
+      </Box>
+      <Box {...defaultArgs} mt="md" textType="note" textSize="lg" textLeading="narrow">
+        <p>Note Large Narrow</p>
+      </Box>
+      <Box {...defaultArgs} mt="md" textType="note" textSize="lg" textLeading="tight">
+        <p>Note Large Tight</p>
+      </Box>
+    </div>
   ),
 };

--- a/src/stories/Box.stories.tsx
+++ b/src/stories/Box.stories.tsx
@@ -192,10 +192,22 @@ export const TextVariations: Story = {
         textLeading="narrow"
       >
         <p>Text Bold</p>
-      </Box>
 
-      <Box {...defaultArgs} mt="lg" backgroundColor="gray" textColor="main" textBold>
-        <p>Text Bold</p>
+        <Box {...defaultArgs} backgroundColor="gray">
+          <p>nested</p>
+        </Box>
+
+        <Box
+          {...defaultArgs}
+          mt="md"
+          backgroundColor="gray"
+          textType="note"
+          textSize="lg"
+          textLeading="tight"
+          textBold={false}
+        >
+          <p>nested. reset styles</p>
+        </Box>
       </Box>
 
       <Box {...defaultArgs} backgroundColor="gray" mt="xl" textColor="main">

--- a/src/types/style.ts
+++ b/src/types/style.ts
@@ -6,6 +6,26 @@ export type Leading = 'default' | 'narrow' | 'tight';
 
 export type TextColor = 'main' | 'sub' | 'link' | 'linkSub' | 'disabled' | 'primary' | 'accent' | 'alert' | 'white';
 
+export type BodyFontSize = Extract<FontSize, 'sm' | 'md' | 'lg'>;
+
+export type BodyLeading = Extract<Leading, 'default' | 'narrow' | 'tight'>;
+
+export type HeadingFontSize = Extract<FontSize, 'xs' | 'sm' | 'md' | 'lg' | 'xl'>;
+
+export type HeadingLeading = Extract<Leading, 'default'>;
+
+export type NoteFontSize = Extract<FontSize, 'sm' | 'md' | 'lg'>;
+
+export type NoteLeading = Extract<Leading, 'default' | 'narrow' | 'tight'>;
+
+export type ButtonFontSize = Extract<FontSize, 'sm' | 'md' | 'lg'>;
+
+export type ButtonLeading = Extract<Leading, 'default'>;
+
+export type TagFontSize = Extract<FontSize, 'sm' | 'md' | 'lg'>;
+
+export type TagLeading = Extract<Leading, 'default'>;
+
 export type Spacing = 'xxs' | 'xs' | 'sm' | 'md' | 'lg' | 'xl' | 'xxl';
 
 export type PaddingProps = {

--- a/src/utils/style.ts
+++ b/src/utils/style.ts
@@ -1,5 +1,19 @@
 import DesignTokens from '@ubie/design-tokens';
-import type { Spacing, Radius } from '../types/style';
+import type {
+  Spacing,
+  Radius,
+  HeadingFontSize,
+  TextType,
+  BodyFontSize,
+  BodyLeading,
+  NoteFontSize,
+  NoteLeading,
+  ButtonFontSize,
+  ButtonLeading,
+  HeadingLeading,
+  TagLeading,
+  TextColor,
+} from '../types/style';
 import type { CSSProperties } from 'react';
 
 export type Opacity = 'normal' | 'darker';
@@ -18,6 +32,128 @@ const createSpacingVariableFromKey = (key: Spacing) => {
 
 const createRadiusVariableFromKey = (key: Radius) => {
   return `var(--${DesignTokens.radius[key].path.join('-')})`;
+};
+
+export const cssFontSizeToken = ({
+  type,
+  size,
+}:
+  | {
+      type: Extract<TextType, 'body'>;
+      size: BodyFontSize;
+    }
+  | {
+      type: Extract<TextType, 'note'>;
+      size: NoteFontSize;
+    }
+  | {
+      type: Extract<TextType, 'heading'>;
+      size: HeadingFontSize;
+    }
+  | {
+      type: Extract<TextType, 'button'>;
+      size: ButtonFontSize;
+    }
+  | {
+      type: Extract<TextType, 'tag'>;
+      size: NoteFontSize;
+    }) => {
+  switch (type) {
+    case 'body':
+      return `var(--${DesignTokens.text[`${type}-${size}-size`].path.join('-')})`;
+    case 'note':
+      return `var(--${DesignTokens.text[`${type}-${size}-size`].path.join('-')})`;
+    case 'heading':
+      return `var(--${DesignTokens.text[`${type}-${size}-size`].path.join('-')})`;
+    case 'button':
+      return `var(--${DesignTokens.text[`${type}-${size}-size`].path.join('-')})`;
+    case 'tag':
+      return `var(--${DesignTokens.text[`${type}-${size}-size`].path.join('-')})`;
+    default:
+      // eslint-disable-next-line no-case-declarations
+      const _: never = type;
+  }
+
+  return '';
+};
+
+export const cssLeadingToken = ({
+  type,
+  size,
+  leading,
+}:
+  | {
+      type: Extract<TextType, 'body'>;
+      size: BodyFontSize;
+      leading: BodyLeading;
+    }
+  | {
+      type: Extract<TextType, 'note'>;
+      size: NoteFontSize;
+      leading: NoteLeading;
+    }
+  | {
+      type: Extract<TextType, 'heading'>;
+      size: HeadingFontSize;
+      leading: HeadingLeading;
+    }
+  | {
+      type: Extract<TextType, 'button'>;
+      size: ButtonFontSize;
+      leading: ButtonLeading;
+    }
+  | {
+      type: Extract<TextType, 'tag'>;
+      size: NoteFontSize;
+      leading: TagLeading;
+    }) => {
+  switch (type) {
+    case 'body':
+      return leading === 'default'
+        ? `var(--${DesignTokens.text[`${type}-${size}-line`].path.join('-')})`
+        : `var(--${DesignTokens.text[`${type}-${size}-${leading}-line`].path.join('-')})`;
+    case 'heading':
+      return `var(--${DesignTokens.text[`${type}-${size}-line`].path.join('-')})`;
+    case 'note':
+      return leading === 'default'
+        ? `var(--${DesignTokens.text[`${type}-${size}-line`].path.join('-')})`
+        : `var(--${DesignTokens.text[`${type}-${size}-${leading}-line`].path.join('-')})`;
+    case 'button':
+      return `var(--${DesignTokens.text[`${type}-${size}-line`].path.join('-')})`;
+    case 'tag':
+      return `var(--${DesignTokens.text[`${type}-${size}-line`].path.join('-')})`;
+    default:
+      // eslint-disable-next-line no-case-declarations
+      const _: never = type;
+  }
+
+  return '';
+};
+
+export const colorVariable = (color: TextColor | undefined): CSSProperties => {
+  if (color == null) {
+    return {
+      '--text-color': 'inherit',
+    } as CSSProperties;
+  }
+
+  let _color = '';
+
+  if (color === 'linkSub') {
+    _color = `var(--${DesignTokens.color[`text-link-sub`].path.join('-')})`;
+  } else if (color === 'primary') {
+    _color = `var(--${DesignTokens.color['primary'].path.join('-')})`;
+  } else if (color === 'accent') {
+    _color = `var(--${DesignTokens.color['accent'].path.join('-')})`;
+  } else if (color === 'alert') {
+    _color = `var(--${DesignTokens.color['alert'].path.join('-')})`;
+  } else {
+    _color = `var(--${DesignTokens.color[`text-${color}`].path.join('-')})`;
+  }
+
+  return {
+    '--text-color': _color,
+  } as CSSProperties;
 };
 
 /**

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,7 +16,6 @@
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "strict": true,
-    "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,


### PR DESCRIPTION
# Overview

- If there is a lot of text, it is cumbersome to place <Text> components
- Answers the need for batch text styling.

# Screenshot

http://localhost:6006/?path=/story/stories-box--text-variations

![スクリーンショット 2024-04-26 14 25 34](https://github.com/ubie-oss/ubie-ui/assets/10903851/899b397c-1009-4b3e-9798-ba781af1623f)
![スクリーンショット 2024-04-26 14 25 42](https://github.com/ubie-oss/ubie-ui/assets/10903851/4cf30dc7-eb8e-4cc8-8e98-e2b5c728f9a0)
