### PR TITLE
Allow Custom Data attributes

### DIFF
--- a/src/components/Accordion/Accordion.tsx
+++ b/src/components/Accordion/Accordion.tsx
@@ -4,6 +4,7 @@ import { ArrowBDownIcon } from '@ubie/ubie-icons';
 import clsx from 'clsx';
 import { FC, PropsWithChildren } from 'react';
 import styles from './Accordion.module.css';
+import { CustomDataAttributeProps } from '../../types/attributes';
 
 export type Size = 'small' | 'medium';
 
@@ -17,11 +18,11 @@ type Props = {
    * @default medium
    */
   size?: Size;
-};
+} & CustomDataAttributeProps;
 
-export const Accordion: FC<PropsWithChildren<Props>> = ({ header, children, size = 'medium' }) => {
+export const Accordion: FC<PropsWithChildren<Props>> = ({ header, children, size = 'medium', ...props }) => {
   return (
-    <details className={clsx(styles.container, styles[size])}>
+    <details className={clsx(styles.container, styles[size])} {...props}>
       <summary className={styles.button}>
         <span>{header}</span>
         <ArrowBDownIcon aria-hidden className={styles.arrow} />

--- a/src/components/ActionHalfModal/ActionHalfModal.tsx
+++ b/src/components/ActionHalfModal/ActionHalfModal.tsx
@@ -4,6 +4,7 @@ import { Dialog, Transition } from '@headlessui/react';
 import { clsx } from 'clsx';
 import { FC, Fragment, PropsWithChildren } from 'react';
 import styles from './ActionHalfModal.module.css';
+import { CustomDataAttributeProps } from '../../types/attributes';
 import { opacityToClassName } from '../../utils/style';
 import { AllOrNone } from '../../utils/types';
 import { Button } from '../Button/Button';
@@ -77,7 +78,7 @@ type SecondaryActionProps = {
   secondaryActionLabel: string;
 };
 
-type Props = BaseProps & AllOrNone<PrimaryActionProps> & AllOrNone<SecondaryActionProps>;
+type Props = BaseProps & AllOrNone<PrimaryActionProps> & AllOrNone<SecondaryActionProps> & CustomDataAttributeProps;
 
 export const ActionHalfModal: FC<PropsWithChildren<Props>> = ({
   children,
@@ -94,12 +95,18 @@ export const ActionHalfModal: FC<PropsWithChildren<Props>> = ({
   open = true,
   isStatic = false,
   fullscreen = false,
+  ...props
 }) => {
   const opacityClassName = opacityToClassName(overlayOpacity);
 
   return (
     <Transition show={open}>
-      <Dialog static={isStatic} onClose={onClose} className={clsx(styles.modal, fullscreen && styles.fullscreen)}>
+      <Dialog
+        static={isStatic}
+        onClose={onClose}
+        className={clsx(styles.modal, fullscreen && styles.fullscreen)}
+        {...props}
+      >
         <Transition.Child
           as={Fragment}
           enter={styles.overlayEnter}

--- a/src/components/ActionModal/ActionModal.tsx
+++ b/src/components/ActionModal/ActionModal.tsx
@@ -5,6 +5,7 @@ import clsx from 'clsx';
 import { FC, Fragment, PropsWithChildren } from 'react';
 import styles from './ActionModal.module.css';
 import { Button } from '../../';
+import { CustomDataAttributeProps } from '../../types/attributes';
 import { opacityToClassName } from '../../utils/style';
 import { AllOrNone } from '../../utils/types';
 
@@ -74,7 +75,7 @@ type SecondaryActionProps = {
   secondaryActionLabel: string;
 };
 
-type Props = PropsWithChildren<BaseProps> & AllOrNone<SecondaryActionProps>;
+type Props = PropsWithChildren<BaseProps> & AllOrNone<SecondaryActionProps> & CustomDataAttributeProps;
 
 export const ActionModal: FC<Props> = ({
   children,
@@ -91,6 +92,7 @@ export const ActionModal: FC<Props> = ({
   showClose = true,
   open = true,
   isStatic = false,
+  ...props
 }) => {
   const opacityClassName = opacityToClassName(overlayOpacity);
 
@@ -105,7 +107,7 @@ export const ActionModal: FC<Props> = ({
       leaveFrom={styles.panelLeaveFrom}
       leaveTo={styles.panelLeaveTo}
     >
-      <Dialog static={isStatic} onClose={onClose} className={styles.modal}>
+      <Dialog static={isStatic} onClose={onClose} className={styles.modal} {...props}>
         <Dialog.Overlay className={clsx(styles.overlay, styles[opacityClassName])} />
         <div className={clsx(styles.modalBody, !header && styles.headerLess, fixedHeight && styles.fixedHeight)}>
           {header && <Dialog.Title className={styles.header}>{header}</Dialog.Title>}

--- a/src/components/Box/Box.tsx
+++ b/src/components/Box/Box.tsx
@@ -5,6 +5,7 @@ import styles from './Box.module.css';
 import {} from '../../types/style';
 import { paddingVariables, marginVariables, radiusVariables } from '../../utils/style';
 import { HTMLTagname } from '../../utils/types';
+import type { CustomDataAttributeProps } from '../../types/attributes';
 import type { PaddingProps, MarginProps, RadiusProp, BackgroundColor } from '../../types/style';
 import type { FC, PropsWithChildren } from 'react';
 
@@ -28,7 +29,8 @@ type Props = {
   width?: 'full';
 } & PaddingProps &
   MarginProps &
-  RadiusProp;
+  RadiusProp &
+  CustomDataAttributeProps;
 
 const capitalize = (str: string) => str.charAt(0).toUpperCase() + str.slice(1);
 
@@ -47,6 +49,7 @@ export const Box: FC<PropsWithChildren<Props>> = ({
   backgroundColor,
   border,
   width,
+  ...props
 }) => {
   return (
     <BoxCopmonent
@@ -71,6 +74,7 @@ export const Box: FC<PropsWithChildren<Props>> = ({
         }),
         ...radiusVariables(radius),
       }}
+      {...props}
     >
       {children}
     </BoxCopmonent>

--- a/src/components/Button/ButtonTypes.ts
+++ b/src/components/Button/ButtonTypes.ts
@@ -39,7 +39,8 @@ export type BaseProps = {
    * 後方配置のアイコン
    */
   suffixIcon?: 'default' | ReactNode;
-} & MarginProps & CustomDataAttributeProps;
+} & MarginProps &
+  CustomDataAttributeProps;
 
 export type OnlyButtonProps = {
   /**

--- a/src/components/Button/ButtonTypes.ts
+++ b/src/components/Button/ButtonTypes.ts
@@ -1,3 +1,4 @@
+import { CustomDataAttributeProps } from '../../types/attributes';
 import type { ButtonHTMLAttributes, ReactNode, AnchorHTMLAttributes, ReactElement } from 'react';
 
 export type BaseProps = {
@@ -37,7 +38,7 @@ export type BaseProps = {
    * 後方配置のアイコン
    */
   suffixIcon?: 'default' | ReactNode;
-};
+} & CustomDataAttributeProps;
 
 export type OnlyButtonProps = {
   /**

--- a/src/components/Center/Center.tsx
+++ b/src/components/Center/Center.tsx
@@ -2,6 +2,7 @@
 
 import clsx from 'clsx';
 import styles from './Center.module.css';
+import { CustomDataAttributeProps } from '../../types/attributes';
 import { paddingVariables } from '../../utils/style';
 import { HTMLTagname } from '../../utils/types';
 import type { PaddingProps } from '../../types/style';
@@ -32,7 +33,8 @@ type Props = {
    * HTMLのID属性の値
    */
   id?: string;
-} & PaddingProps;
+} & PaddingProps &
+  CustomDataAttributeProps;
 
 export const Center: FC<PropsWithChildren<Props>> = ({
   as: CenterCopmonent = 'div',
@@ -45,6 +47,7 @@ export const Center: FC<PropsWithChildren<Props>> = ({
   childrenCenter,
   id,
   maxWidth = 'none',
+  ...props
 }) => {
   return (
     <CenterCopmonent
@@ -61,6 +64,7 @@ export const Center: FC<PropsWithChildren<Props>> = ({
           }),
         } as CSSProperties
       }
+      {...props}
     >
       {children}
     </CenterCopmonent>

--- a/src/components/Center/Center.tsx
+++ b/src/components/Center/Center.tsx
@@ -35,7 +35,8 @@ type Props = {
    * HTMLのID属性の値
    */
   id?: string;
-} & MarginYProps & PaddingProps &
+} & MarginYProps &
+  PaddingProps &
   CustomDataAttributeProps;
 
 export const Center: FC<PropsWithChildren<Props>> = ({

--- a/src/components/CheckboxGroup/CheckboxGroup.tsx
+++ b/src/components/CheckboxGroup/CheckboxGroup.tsx
@@ -25,7 +25,13 @@ export type Props = {
   direction?: 'column' | 'row';
 } & CustomDataAttributeProps;
 
-export const CheckboxGroup: FC<Props> = ({ children, label, showRequiredLabel, direction = 'column', ...otherProps }) => {
+export const CheckboxGroup: FC<Props> = ({
+  children,
+  label,
+  showRequiredLabel,
+  direction = 'column',
+  ...otherProps
+}) => {
   return (
     <fieldset className={styles.wrapper} {...otherProps}>
       <legend className={styles.legend}>

--- a/src/components/CheckboxGroup/CheckboxGroup.tsx
+++ b/src/components/CheckboxGroup/CheckboxGroup.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import styles from './CheckboxGroup.module.css';
+import { CustomDataAttributeProps } from '../../types/attributes'; // 追加したインポート
 import { Checkbox } from '../Checkbox/Checkbox';
 import { Flex } from '../Flex/Flex';
 import type { FC, ReactElement } from 'react';
@@ -16,11 +17,11 @@ export type Props = {
    * @default column
    */
   direction?: 'column' | 'row';
-};
+} & CustomDataAttributeProps;
 
-export const CheckboxGroup: FC<Props> = ({ children, label, direction = 'column' }) => {
+export const CheckboxGroup: FC<Props> = ({ children, label, direction = 'column', ...otherProps }) => {
   return (
-    <fieldset className={styles.wrapper}>
+    <fieldset className={styles.wrapper} {...otherProps}>
       <legend className={styles.legend}>{label}</legend>
       <Flex spacing="md" direction={direction}>
         {children}

--- a/src/components/ErrorMessage/ErrorMessage.tsx
+++ b/src/components/ErrorMessage/ErrorMessage.tsx
@@ -1,14 +1,15 @@
 'use client';
 
 import styles from './ErrorMessage.module.css';
+import { CustomDataAttributeProps } from '../../types/attributes'; // 追加したインポート
 import type { FC, ReactNode } from 'react';
 
 type Props = {
   children: ReactNode;
-};
+} & CustomDataAttributeProps;
 
-export const ErrorMessage: FC<Props> = ({ children }) => (
-  <p aria-live="polite" className={styles.error}>
+export const ErrorMessage: FC<Props> = ({ children, ...otherProps }) => (
+  <p aria-live="polite" className={styles.error} {...otherProps}>
     {children}
   </p>
 );

--- a/src/components/Flex/Flex.tsx
+++ b/src/components/Flex/Flex.tsx
@@ -50,7 +50,8 @@ type Props = {
    */
   width?: 'full';
 } & MarginProps &
-  PaddingProps & CustomDataAttributeProps;;
+  PaddingProps &
+  CustomDataAttributeProps;
 
 export const Flex: FC<PropsWithChildren<Props>> = ({
   as: FlexCopmonent = 'div',
@@ -106,7 +107,7 @@ export const Flex: FC<PropsWithChildren<Props>> = ({
           ml,
         }),
       },
-      ...otherProps
+      ...otherProps,
     },
     children,
   );

--- a/src/components/Flex/Flex.tsx
+++ b/src/components/Flex/Flex.tsx
@@ -2,6 +2,7 @@
 
 import clsx from 'clsx';
 import styles from './Flex.module.css';
+import { CustomDataAttributeProps } from '../../types/attributes'; // 追加したインポート
 import { Spacing, AlignItems, JustifyContent, FlexDirection } from '../../types/style';
 import { HTMLTagname } from '../../utils/types';
 import type { FC, PropsWithChildren } from 'react';
@@ -44,7 +45,7 @@ type Props = {
    * デフォルトで<Flex>は横幅いっぱいを専有する。しかし例えば、フレックスコンテナの子要素として配置した場合、横幅が自身の子に合わせて小さくなる。これが不都合の場合に100%とする事が可能
    */
   width?: 'full';
-};
+} & CustomDataAttributeProps;
 
 export const Flex: FC<PropsWithChildren<Props>> = ({
   as: FlexCopmonent = 'div',
@@ -56,6 +57,7 @@ export const Flex: FC<PropsWithChildren<Props>> = ({
   spacing,
   height,
   width,
+  ...otherProps
 }) => {
   // Directly specifying the markuplint will result in a markuplint error.
   const gapStyle = spacing ? `var(--size-spacing-${spacing})` : '0';
@@ -72,6 +74,7 @@ export const Flex: FC<PropsWithChildren<Props>> = ({
           '--flex-wrap': wrap ? 'wrap' : 'nowrap',
         } as React.CSSProperties
       }
+      {...otherProps}
     >
       {children}
     </FlexCopmonent>

--- a/src/components/Heading/Heading.tsx
+++ b/src/components/Heading/Heading.tsx
@@ -55,7 +55,7 @@ type Props = {
    * @default true
    */
   bold?: boolean;
-} & CustomDataAttributeProps;;
+} & CustomDataAttributeProps;
 
 const Heading: FC<PropsWithChildren<Props>> = ({
   textAlign,

--- a/src/components/Heading/Heading.tsx
+++ b/src/components/Heading/Heading.tsx
@@ -1,5 +1,6 @@
 import { clsx } from 'clsx';
 import styles from './Heading.module.css';
+import { CustomDataAttributeProps } from '../../types/attributes'; // 追加したインポート
 import { HTMLTagname } from '../../utils/types';
 import type { FC, PropsWithChildren, ReactNode } from 'react';
 
@@ -49,7 +50,7 @@ type Props = {
    * HTMLのfor属性。label要素の場合に使用
    */
   htmlFor?: string;
-};
+} & CustomDataAttributeProps;
 
 const Heading: FC<PropsWithChildren<Props>> = ({
   textAlign = 'left',
@@ -63,6 +64,7 @@ const Heading: FC<PropsWithChildren<Props>> = ({
   as: HeadingComponent = 'p',
   id,
   htmlFor,
+  ...otherProps
 }) => {
   const className = clsx(
     styles.heading,
@@ -74,7 +76,7 @@ const Heading: FC<PropsWithChildren<Props>> = ({
   );
 
   return (
-    <HeadingComponent className={className} id={id} htmlFor={htmlFor}>
+    <HeadingComponent className={className} id={id} htmlFor={htmlFor} {...otherProps}>
       {primaryIcon && (
         <span aria-hidden className={clsx(styles.icon, styles.primary)}>
           {primaryIcon}

--- a/src/components/HelperMessage/HelperMessage.tsx
+++ b/src/components/HelperMessage/HelperMessage.tsx
@@ -1,10 +1,15 @@
 'use client';
 
 import styles from './HelperMessage.module.css';
+import { CustomDataAttributeProps } from '../../types/attributes'; // 追加したインポート
 import type { FC, ReactNode } from 'react';
 
 type Props = {
   children: ReactNode;
-};
+} & CustomDataAttributeProps;
 
-export const HelperMessage: FC<Props> = ({ children }) => <p className={styles.message}>{children}</p>;
+export const HelperMessage: FC<Props> = ({ children, ...otherProps }) => (
+  <p className={styles.message} {...otherProps}>
+    {children}
+  </p>
+);

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -3,6 +3,7 @@
 import { clsx } from 'clsx';
 import { FC, forwardRef, InputHTMLAttributes } from 'react';
 import styles from './Input.module.css';
+import { CustomDataAttributeProps } from '../../types/attributes'; // 追加したインポート
 
 type Props = {
   /**
@@ -27,7 +28,8 @@ type Props = {
    * 値が変化した場合のコールバック
    */
   onChange?: InputHTMLAttributes<HTMLInputElement>['onChange'];
-} & Omit<InputHTMLAttributes<HTMLInputElement>, 'id' | 'invalid' | 'value' | 'disabled' | 'onChange'>;
+} & Omit<InputHTMLAttributes<HTMLInputElement>, 'id' | 'invalid' | 'value' | 'disabled' | 'onChange'> &
+  CustomDataAttributeProps;
 
 export const Input: FC<Props> = forwardRef<HTMLInputElement, Props>(({ isInvalid, ...props }, ref) => {
   const className = clsx({ [styles.isInvalid]: isInvalid && !props.disabled }, styles.input, props.className);

--- a/src/components/Label/Label.tsx
+++ b/src/components/Label/Label.tsx
@@ -23,7 +23,13 @@ type Props = {
   showRequiredLabel?: boolean;
 } & CustomDataAttributeProps;
 
-export const Label: FC<Props> = ({ children, as: LabelComponent = 'label', htmlFor, showRequiredLabel, ...otherProps }) => {
+export const Label: FC<Props> = ({
+  children,
+  as: LabelComponent = 'label',
+  htmlFor,
+  showRequiredLabel,
+  ...otherProps
+}) => {
   return (
     <LabelComponent htmlFor={htmlFor} className={styles.label} {...otherProps}>
       {children}

--- a/src/components/Label/Label.tsx
+++ b/src/components/Label/Label.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import styles from './Label.module.css';
+import { CustomDataAttributeProps } from '../../types/attributes'; // 追加したインポート
 import type { ElementType, FC, ReactNode } from 'react';
 
 type Props = {
@@ -14,11 +15,11 @@ type Props = {
    * ラベルが紐づくフォーム要素のid属性。asにlabelを指定した場合に必用
    */
   htmlFor?: string;
-};
+} & CustomDataAttributeProps;
 
-export const Label: FC<Props> = ({ children, as: LabelComponent = 'label', htmlFor }) => {
+export const Label: FC<Props> = ({ children, as: LabelComponent = 'label', htmlFor, ...otherProps }) => {
   return (
-    <LabelComponent htmlFor={htmlFor} className={styles.label}>
+    <LabelComponent htmlFor={htmlFor} className={styles.label} {...otherProps}>
       {children}
     </LabelComponent>
   );

--- a/src/components/LinkCard/LinkCard.tsx
+++ b/src/components/LinkCard/LinkCard.tsx
@@ -4,6 +4,7 @@ import { ArrowBRightIcon } from '@ubie/ubie-icons';
 import clsx from 'clsx';
 import { cloneElement, forwardRef } from 'react';
 import styles from './LinkCard.module.css';
+import { CustomDataAttributeProps } from '../../types/attributes'; // 追加したインポート
 import type { ComponentType, ReactElement, ReactNode } from 'react';
 
 type Props = {
@@ -37,7 +38,7 @@ type Props = {
    * アイコン
    */
   icon?: ComponentType<{ className?: string }>;
-};
+} & CustomDataAttributeProps;
 
 export const LinkCard = forwardRef<HTMLAnchorElement, Props>(
   ({ title, size = 'medium', className, icon: IconComponent, description, render, ...props }, forwardedRef) => {

--- a/src/components/MessageModal/MessageModal.tsx
+++ b/src/components/MessageModal/MessageModal.tsx
@@ -5,6 +5,7 @@ import clsx from 'clsx';
 import { FC, Fragment, PropsWithChildren } from 'react';
 import styles from './MessageModal.module.css';
 import { Button } from '../../';
+import { CustomDataAttributeProps } from '../../types/attributes'; // 追加したインポート
 import { opacityToClassName } from '../../utils/style';
 
 type Opacity = 'normal' | 'darker';
@@ -43,7 +44,8 @@ type Props = {
    * @default false
    */
   isStatic?: boolean;
-} & PropsWithChildren;
+} & PropsWithChildren &
+  CustomDataAttributeProps;
 
 export const MessageModal: FC<Props> = ({
   header,
@@ -54,6 +56,7 @@ export const MessageModal: FC<Props> = ({
   fixedHeight = false,
   open = true,
   isStatic = false,
+  ...otherProps
 }) => {
   const opacityClassName = opacityToClassName(overlayOpacity);
 
@@ -68,7 +71,7 @@ export const MessageModal: FC<Props> = ({
       leaveFrom={styles.panelLeaveFrom}
       leaveTo={styles.panelLeaveTo}
     >
-      <Dialog static={isStatic} onClose={onClose} className={styles.modal}>
+      <Dialog static={isStatic} onClose={onClose} className={styles.modal} {...otherProps}>
         <Dialog.Overlay className={clsx(styles.overlay, styles[opacityClassName])} />
         <div className={clsx(styles.modalBody, fixedHeight && styles.fixedHeight)}>
           {header && <Dialog.Title className={styles.header}>{header}</Dialog.Title>}

--- a/src/components/RadioButton/RadioButton.tsx
+++ b/src/components/RadioButton/RadioButton.tsx
@@ -3,6 +3,7 @@
 import clsx from 'clsx';
 import { FC, InputHTMLAttributes } from 'react';
 import styles from './RadioButton.module.css';
+import { CustomDataAttributeProps } from '../../types/attributes';
 
 type RadioProps = Required<Pick<InputHTMLAttributes<HTMLInputElement>, 'onChange' | 'checked'>> &
   Omit<InputHTMLAttributes<HTMLInputElement>, 'size' | 'children' | 'value' | 'name'>;
@@ -25,7 +26,8 @@ type Props = {
    * @default medium
    */
   size?: 'medium' | 'small';
-} & RadioProps;
+} & RadioProps &
+  CustomDataAttributeProps;
 
 export const RadioButton: FC<Props> = ({
   size = 'medium',

--- a/src/components/RadioCard/RadioCard.tsx
+++ b/src/components/RadioCard/RadioCard.tsx
@@ -3,26 +3,28 @@
 import { clsx } from 'clsx';
 import { FC, forwardRef } from 'react';
 import styles from './RadioCard.module.css';
+import { CustomDataAttributeProps } from '../../types/attributes'; // 追加したインポート
 
-type Props = Omit<React.InputHTMLAttributes<HTMLInputElement>, 'name' | 'value' | 'children'> & {
-  /**
-   * グループ化（排他制御）したい要素には同じ名前をつける
-   */
-  name: string;
-  /**
-   * 選択時のコールバックで渡される値
-   */
-  value: string | number;
-  /**
-   * * ラベルに表示されるテキストまたは要素
-   */
-  children: React.InputHTMLAttributes<HTMLInputElement>['children'];
-  /**
-   * 横幅を100%占有するかどうか
-   * @default false
-   */
-  block?: boolean;
-};
+type Props = Omit<React.InputHTMLAttributes<HTMLInputElement>, 'name' | 'value' | 'children'> &
+  CustomDataAttributeProps & {
+    /**
+     * グループ化（排他制御）したい要素には同じ名前をつける
+     */
+    name: string;
+    /**
+     * 選択時のコールバックで渡される値
+     */
+    value: string | number;
+    /**
+     * ラベルに表示されるテキストまたは要素
+     */
+    children: React.InputHTMLAttributes<HTMLInputElement>['children'];
+    /**
+     * 横幅を100%占有するかどうか
+     * @default false
+     */
+    block?: boolean;
+  };
 
 /**
  * アクセシビリティに配慮したラジオボタン。
@@ -38,8 +40,8 @@ const RadioCard: FC<Props> = forwardRef<HTMLInputElement, Props>(
           value={value}
           checked={checked}
           className={clsx(className, styles.radio)}
-          {...otherProps}
           ref={ref}
+          {...otherProps}
         />
         {children}
       </label>

--- a/src/components/RadioGroup/RadioGroup.tsx
+++ b/src/components/RadioGroup/RadioGroup.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import styles from './RadioGroup.module.css';
+import { CustomDataAttributeProps } from '../../types/attributes'; // 追加したインポート
 import { Flex } from '../Flex/Flex';
 import { RadioButton } from '../RadioButton/RadioButton';
 import { RadioCard } from '../RadioCard/RadioCard';
@@ -19,14 +20,14 @@ export type Props = {
    * @default column
    */
   direction?: 'column' | 'row';
-};
+} & CustomDataAttributeProps;
 
-export const RadioGroup: FC<Props> = ({ children, label, direction = 'column' }) => {
+export const RadioGroup: FC<Props> = ({ children, label, direction = 'column', ...otherProps }) => {
   const childrenIsCard = children.some((child) => child.type === RadioCard);
   const childenIsBlock = direction === 'row' || (childrenIsCard && direction === 'column');
 
   return (
-    <fieldset className={styles.wrapper}>
+    <fieldset className={styles.wrapper} {...otherProps}>
       <legend className={styles.legend}>{label}</legend>
       <Flex
         spacing={childrenIsCard ? 'sm' : 'md'}

--- a/src/components/RadioGroup/RadioGroup.tsx
+++ b/src/components/RadioGroup/RadioGroup.tsx
@@ -28,7 +28,13 @@ export type Props = {
   direction?: 'column' | 'row';
 } & CustomDataAttributeProps;
 
-export const RadioGroup: FC<Props> = ({ children, label, showRequiredLabel = false, direction = 'column', ...otherProps }) => {
+export const RadioGroup: FC<Props> = ({
+  children,
+  label,
+  showRequiredLabel = false,
+  direction = 'column',
+  ...otherProps
+}) => {
   const childrenIsCard = children.some((child) => child.type === RadioCard);
   const childenIsBlock = direction === 'row' || (childrenIsCard && direction === 'column');
 

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -4,8 +4,9 @@ import { UnfoldMoreIcon } from '@ubie/ubie-icons';
 import clsx from 'clsx';
 import { FC, forwardRef, InputHTMLAttributes } from 'react';
 import styles from './Select.module.css';
+import { CustomDataAttributeProps } from '../../types/attributes';
 
-type Props = {
+type Props = CustomDataAttributeProps & {
   /**
    * ネイティブ要素の `id` 属性。ページで固有のIDを指定
    */

--- a/src/components/Stack/Stack.tsx
+++ b/src/components/Stack/Stack.tsx
@@ -3,10 +3,11 @@
 import { clsx } from 'clsx';
 import { FC, ReactNode } from 'react';
 import styles from './Stack.module.css';
+import { CustomDataAttributeProps } from '../../types/attributes'; // 追加したインポート
 import { Spacing, AlignItems, JustifyContent } from '../../types/style';
 import { HTMLTagname } from '../../utils/types';
 
-type Props = {
+type Props = CustomDataAttributeProps & {
   /**
    * レンダリングされるコンポーネントまたはHTML要素
    * @default div
@@ -48,6 +49,7 @@ export const Stack: FC<Props> = ({
   spacing,
   alignItems = 'flex-start',
   justifyContent = 'flex-start',
+  ...otherProps
 }) => {
   return (
     <StackComponent
@@ -57,6 +59,7 @@ export const Stack: FC<Props> = ({
         gap: `var(--size-spacing-${spacing})`,
       }}
       className={clsx(className, styles.stack)}
+      {...otherProps}
     >
       {children}
     </StackComponent>

--- a/src/components/Text/Text.tsx
+++ b/src/components/Text/Text.tsx
@@ -3,6 +3,7 @@
 import { clsx } from 'clsx';
 import { FC, ReactNode } from 'react';
 import styles from './Text.module.css';
+import { CustomDataAttributeProps } from '../../types/attributes';
 import { TextColor } from '../../types/style';
 import { HTMLTagname } from '../../utils/types';
 
@@ -30,7 +31,7 @@ type BaseProps = {
    * HTMLのid属性
    */
   id?: string;
-};
+} & CustomDataAttributeProps;
 
 type BodyFontSize = 'sm' | 'md' | 'lg';
 type BodyLeading = 'default' | 'narrow' | 'tight';
@@ -134,11 +135,13 @@ export const Text: FC<TextProps> = ({
   color = 'main',
   children,
   id,
+  ...props
 }) => {
   return (
     <TextComponent
       id={id}
       className={clsx(styles.text, bold && styles.bold, styles[size], styles[type], styles[leading], styles[color])}
+      {...props}
     >
       {children}
     </TextComponent>

--- a/src/components/TextArea/TextArea.tsx
+++ b/src/components/TextArea/TextArea.tsx
@@ -3,6 +3,7 @@
 import clsx from 'clsx';
 import { FC, TextareaHTMLAttributes } from 'react';
 import styles from './TextArea.module.css';
+import { CustomDataAttributeProps } from '../../types/attributes';
 
 type Props = {
   /**
@@ -27,7 +28,8 @@ type Props = {
    * 値が変化した場合のコールバック
    */
   onChange?: TextareaHTMLAttributes<HTMLTextAreaElement>['onChange'];
-} & Omit<TextareaHTMLAttributes<HTMLTextAreaElement>, 'id' | 'value' | 'onChange'>;
+} & Omit<TextareaHTMLAttributes<HTMLTextAreaElement>, 'id' | 'value' | 'onChange'> &
+  CustomDataAttributeProps;
 
 export const TextArea: FC<Props> = ({ isInvalid = false, className, ...props }) => {
   const _className = clsx({ [styles.isInvalid]: isInvalid }, styles.textArea, className);

--- a/src/components/Toggle/Toggle.tsx
+++ b/src/components/Toggle/Toggle.tsx
@@ -3,6 +3,7 @@
 import clsx from 'clsx';
 import { FC, InputHTMLAttributes, forwardRef, useRef, useState } from 'react';
 import styles from './Toggle.module.css';
+import { CustomDataAttributeProps } from '../../types/attributes';
 
 type Props = {
   /**
@@ -23,9 +24,10 @@ type Props = {
    * @default false
    */
   disabled?: boolean;
-} & Omit<InputHTMLAttributes<HTMLInputElement>, 'children' | 'onChange'>;
+} & Omit<InputHTMLAttributes<HTMLInputElement>, 'children' | 'onChange'> &
+  CustomDataAttributeProps;
 
-export const Toggle: FC<Props> = forwardRef<HTMLLabelElement, Props>(
+export const Toggle: FC<Props> = forwardRef<HTMLInputElement, Props>(
   ({ checked: checkedProps, defaultChecked, onChange, ...otherProps }, ref) => {
     const { current: isUnControlled } = useRef(checkedProps === undefined);
     const [isUnControlledChecked, setIsUnControlledChecked] = useState(defaultChecked);
@@ -40,8 +42,9 @@ export const Toggle: FC<Props> = forwardRef<HTMLLabelElement, Props>(
     };
 
     return (
-      <label ref={ref} className={clsx(styles.root, isChecked ? styles.on : styles.off)}>
+      <label className={clsx(styles.root, isChecked ? styles.on : styles.off)}>
         <input
+          ref={ref}
           type="checkbox"
           role="switch"
           checked={isChecked}

--- a/src/stories/Accordion.stories.tsx
+++ b/src/stories/Accordion.stories.tsx
@@ -1,5 +1,6 @@
 import { Meta, StoryObj } from '@storybook/react';
 import { Accordion } from '..';
+import type { ComponentProps } from 'react';
 
 export default {
   component: Accordion,
@@ -7,18 +8,29 @@ export default {
 
 type Story = StoryObj<typeof Accordion>;
 
+const defaultArgs = {
+  header: '夏目漱石「私の個人主義」',
+  children:
+    '何は時分どうもどんな観念顔というののところを云ったいまし。とうてい今日に説明院は現にこういう反対たますくらいから思わて来るないにも撲殺なるたたて、始終にも願うただですん。',
+} satisfies Partial<ComponentProps<typeof Accordion>>;
+
 export const Default: Story = {
-  render: () => (
-    <Accordion header="夏目漱石「私の個人主義」">
-      何は時分どうもどんな観念顔というののところを云ったいまし。とうてい今日に説明院は現にこういう反対たますくらいから思わて来るないにも撲殺なるたたて、始終にも願うただですん。
-    </Accordion>
-  ),
+  render: (args) => <Accordion {...args}></Accordion>,
+  args: defaultArgs,
 };
 
 export const Small: Story = {
-  render: () => (
-    <Accordion header="夏目漱石「私の個人主義」" size="small">
-      何は時分どうもどんな観念顔というののところを云ったいまし。とうてい今日に説明院は現にこういう反対たますくらいから思わて来るないにも撲殺なるたたて、始終にも願うただですん。
-    </Accordion>
-  ),
+  render: (args) => <Accordion {...args}></Accordion>,
+  args: {
+    ...defaultArgs,
+    size: 'small',
+  },
+};
+
+export const CustomDataAttribute: Story = {
+  render: (args) => <Accordion {...args}></Accordion>,
+  args: {
+    ...defaultArgs,
+    ['data-test-id']: 'some-id',
+  },
 };

--- a/src/stories/ActionHalfModal.stories.tsx
+++ b/src/stories/ActionHalfModal.stories.tsx
@@ -112,7 +112,10 @@ export const NoCloseButton: Story = {
       </>
     );
   },
-  args: defaultArgs,
+  args: {
+    ...defaultArgs,
+    [`data-test-id`]: 'some-id',
+  },
 };
 
 export const Customized: Story = {
@@ -136,6 +139,33 @@ export const Customized: Story = {
           overlayOpacity="darker"
           closeLabel="キャンセル"
           {...args}
+          open={open}
+          onClose={onClose}
+        />
+      </>
+    );
+  },
+  args: defaultArgs,
+};
+
+export const CustomDataAttribute: Story = {
+  render: (args) => {
+    const [open, setOpen] = useState(false);
+
+    const onClose = useCallback(() => {
+      setOpen(false);
+    }, []);
+
+    return (
+      <>
+        <button type="button" onClick={() => setOpen(true)}>
+          Open Modal
+        </button>
+        <ActionHalfModal
+          {...args}
+          data-test-id="some-id"
+          primaryActionLabel="アクション"
+          onPrimaryAction={onClose}
           open={open}
           onClose={onClose}
         />

--- a/src/stories/ActionModal.stories.tsx
+++ b/src/stories/ActionModal.stories.tsx
@@ -104,3 +104,24 @@ export const Customized: Story = {
     closeLabel: 'キャンセル',
   },
 };
+
+export const CustomDataAttribute: Story = {
+  render: (args) => {
+    const [open, setOpen] = useState(false);
+
+    return (
+      <>
+        <button type="button" onClick={() => setOpen(true)}>
+          Open Modal
+        </button>
+        <ActionModal {...args} open={open} onPrimaryAction={() => setOpen(false)} onClose={() => setOpen(false)}>
+          <p>Default</p>
+        </ActionModal>
+      </>
+    );
+  },
+  args: {
+    ...defaultArgs,
+    [`data-test-id`]: 'some-id',
+  },
+};

--- a/src/stories/Box.stories.tsx
+++ b/src/stories/Box.stories.tsx
@@ -174,3 +174,11 @@ export const AsSection: Story = {
     </Box>
   ),
 };
+
+export const CustomDataAttribute: Story = {
+  render: (args) => <Box {...args} />,
+  args: {
+    ['data-test-id']: 'some-test',
+    ...defaultArgs,
+  },
+};

--- a/src/stories/Button.stories.tsx
+++ b/src/stories/Button.stories.tsx
@@ -130,3 +130,11 @@ export const Disabled: Story = {
   ),
   args: defaultArgs,
 };
+
+export const CustomDataAttribute: Story = {
+  render: (args) => <Button {...args} />,
+  args: {
+    ['data-test-id']: 'some-test',
+    ...defaultArgs,
+  },
+};

--- a/src/stories/Center.stories.tsx
+++ b/src/stories/Center.stories.tsx
@@ -58,3 +58,11 @@ export const AsSection: Story = {
     </Center>
   ),
 };
+
+export const CustomDataAttribute: Story = {
+  render: () => (
+    <Center maxWidth="400px" data-test-id="some-id">
+      Center
+    </Center>
+  ),
+};

--- a/src/stories/Checkbox.stories.tsx
+++ b/src/stories/Checkbox.stories.tsx
@@ -132,3 +132,16 @@ export const Disabled: Story = {
     </Stack>
   ),
 };
+
+export const CustomDataAttribute: Story = {
+  render: () => (
+    <Stack spacing="xs">
+      <Checkbox name="custom-data" value="data1" data-test-id="checkbox-data1">
+        Data 1
+      </Checkbox>
+      <Checkbox name="custom-data" value="data2" data-test-id="checkbox-data2">
+        Data 2
+      </Checkbox>
+    </Stack>
+  ),
+};

--- a/src/stories/ErrorMessage.stories.tsx
+++ b/src/stories/ErrorMessage.stories.tsx
@@ -11,3 +11,7 @@ type Story = StoryObj<typeof ErrorMessage>;
 export const Default: Story = {
   render: () => <ErrorMessage>全角カタカナでご入力ください</ErrorMessage>,
 };
+
+export const CustomDataAttribute: Story = {
+  render: () => <ErrorMessage data-test-id="error-message-custom">全角カタカナでご入力ください</ErrorMessage>,
+};

--- a/src/stories/Flex.stories.tsx
+++ b/src/stories/Flex.stories.tsx
@@ -170,3 +170,11 @@ export const AsSection: Story = {
     </Flex>
   ),
 };
+
+export const CustomDataAttribute: Story = {
+  render: () => (
+    <Flex data-test-id="flex-custom-attribute" spacing="md" alignItems="center">
+      <div>Flex component with custom data attribute</div>
+    </Flex>
+  ),
+};

--- a/src/stories/Heading.stories.tsx
+++ b/src/stories/Heading.stories.tsx
@@ -270,3 +270,10 @@ export const Icon: Story = {
     </Stack>
   ),
 };
+
+export const CustomDataAttribute: Story = {
+  render: (args) => <Heading {...args}>Heading with Custom Data Attribute</Heading>,
+  args: {
+    [`data-test-id`]: 'heading-custom-attribute',
+  },
+};

--- a/src/stories/HelperMessage.stories.tsx
+++ b/src/stories/HelperMessage.stories.tsx
@@ -11,3 +11,10 @@ type Story = StoryObj<typeof HelperMessage>;
 export const Default: Story = {
   render: () => <HelperMessage>例: 2000年12月1日</HelperMessage>,
 };
+
+export const CustomDataAttribute: Story = {
+  args: {
+    'data-test-id': 'helper-message-custom-attribute',
+  },
+  render: (args) => <HelperMessage {...args}>This is a custom data attribute example</HelperMessage>,
+};

--- a/src/stories/Input.stories.tsx
+++ b/src/stories/Input.stories.tsx
@@ -115,3 +115,9 @@ export const Disabled: Story = {
 export const IsInvalid: Story = {
   render: () => <Input value="wrong value" isInvalid />,
 };
+export const CustomDataAttribute: Story = {
+  args: {
+    'data-test-id': 'input-custom-attribute',
+  },
+  render: (args) => <Input {...args} />,
+};

--- a/src/stories/Label.stories.tsx
+++ b/src/stories/Label.stories.tsx
@@ -11,3 +11,14 @@ type Story = StoryObj<typeof Label>;
 export const Default: Story = {
   render: () => <Label htmlFor="id">全角カタカナでご入力ください</Label>,
 };
+
+export const CustomDataAttribute: Story = {
+  args: {
+    'data-test-id': 'label-test-id',
+  },
+  render: (args) => (
+    <Label {...args} htmlFor="id">
+      Please enter in English
+    </Label>
+  ),
+};

--- a/src/stories/LinkButton.stories.tsx
+++ b/src/stories/LinkButton.stories.tsx
@@ -115,3 +115,11 @@ export const Block: Story = {
     </div>
   ),
 };
+
+export const CustomDataAttribute: Story = {
+  args: {
+    ...defaultArgs,
+    'data-test-id': 'link-button-custom-attribute',
+  },
+  render: (args) => <LinkButton {...args}>Please enter in English</LinkButton>,
+};

--- a/src/stories/LinkCard.stories.tsx
+++ b/src/stories/LinkCard.stories.tsx
@@ -54,3 +54,11 @@ export const SizeSmall: Story = {
   },
   args: defaultArgs,
 };
+
+export const CustomDataAttribute: Story = {
+  render: (args) => <LinkCard {...args} href="https://vitals.ubie.life/" />,
+  args: {
+    ...defaultArgs,
+    'data-test-id': 'link-card-custom-attribute',
+  },
+};

--- a/src/stories/MessageModal.stories.tsx
+++ b/src/stories/MessageModal.stories.tsx
@@ -43,7 +43,7 @@ export const Default: Story = {
 
 export const WithHeader: Story = {
   render: (args) => {
-    const [open, setOpen] = useState(true);
+    const [open, setOpen] = useState(false);
 
     return (
       <>
@@ -62,7 +62,7 @@ export const WithHeader: Story = {
 
 export const FixedHeight: Story = {
   render: (args) => {
-    const [open, setOpen] = useState(true);
+    const [open, setOpen] = useState(false);
 
     return (
       <>
@@ -81,7 +81,7 @@ export const FixedHeight: Story = {
 
 export const OverlayDarker: Story = {
   render: (args) => {
-    const [open, setOpen] = useState(true);
+    const [open, setOpen] = useState(false);
 
     return (
       <>
@@ -95,5 +95,24 @@ export const OverlayDarker: Story = {
   args: {
     ...defaultArgs,
     overlayOpacity: 'darker',
+  },
+};
+
+export const CustomDataAttribute: Story = {
+  render: (args) => {
+    const [open, setOpen] = useState(false);
+
+    return (
+      <>
+        <button type="button" onClick={() => setOpen(true)}>
+          Open Modal
+        </button>
+        <MessageModal {...args} open={open} onClose={() => setOpen(false)} />
+      </>
+    );
+  },
+  args: {
+    ...defaultArgs,
+    'data-test-id': 'message-modal-custom',
   },
 };

--- a/src/stories/RadioButton.stories.tsx
+++ b/src/stories/RadioButton.stories.tsx
@@ -120,3 +120,17 @@ export const Disabled: Story = {
     name: 'disabled',
   },
 };
+
+export const CustomDataAttribute: Story = {
+  render: (args) => (
+    <Stack spacing="xs">
+      <RadioButton {...args} value="data1" id="data1" name="customData" data-test-id="1">
+        Data 1
+      </RadioButton>
+      <RadioButton {...args} value="data2" id="data2" name="customData" data-test-id="2">
+        Data 2
+      </RadioButton>
+    </Stack>
+  ),
+  args: defaultArgs,
+};

--- a/src/stories/RadioCard.stories.tsx
+++ b/src/stories/RadioCard.stories.tsx
@@ -101,3 +101,33 @@ export const Block: Story = {
     block: true,
   },
 };
+
+export const CustomDataAttribute: Story = {
+  args: defaultArgs,
+  render: (args) => {
+    const options = ['option1', 'option2', 'option3'];
+    const [value, setValue] = useState<string>('option1');
+
+    const onChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+      setValue(event.target.value);
+    };
+
+    return (
+      <Stack spacing="sm">
+        {options.map((option, index) => (
+          <RadioCard
+            {...args}
+            key={option}
+            checked={value === option}
+            value={option}
+            onChange={onChange}
+            name="customDataAttribute"
+            data-test-id={index}
+          >
+            {option}
+          </RadioCard>
+        ))}
+      </Stack>
+    );
+  },
+};

--- a/src/stories/Select.stories.tsx
+++ b/src/stories/Select.stories.tsx
@@ -75,3 +75,23 @@ export const IsInvalid: StoryObj<typeof Select> = {
     isInvalid: true,
   },
 };
+
+export const CustomDataAttribute: StoryObj<typeof Select> = {
+  render: (args) => {
+    const options = ['option1', 'option2', 'option3'];
+
+    return (
+      <Select {...args} value={options[0]}>
+        {options.map((o) => (
+          <option key={o} data-test-id={args['data-test-id']}>
+            {o}
+          </option>
+        ))}
+      </Select>
+    );
+  },
+  args: {
+    ...defaultArgs,
+    'data-test-id': 'select-custom-data-attribute',
+  },
+};

--- a/src/stories/Stack.stories.tsx
+++ b/src/stories/Stack.stories.tsx
@@ -95,3 +95,12 @@ export const BlockLevelElementsToFullWidth: Story = {
   ),
   args: defaultArgs,
 };
+
+export const CustomDataAttribute: Story = {
+  render: (args) => (
+    <Stack {...args}>
+      <p>This is a paragraph.</p>
+    </Stack>
+  ),
+  args: { ...defaultArgs, 'data-test-id': 'custom-attribute' },
+};

--- a/src/stories/Text.stories.tsx
+++ b/src/stories/Text.stories.tsx
@@ -306,3 +306,11 @@ export const TextInText: Story = {
     </Text>
   ),
 };
+
+export const CustomDataAttribute: Story = {
+  render: () => (
+    <Text date-test-id="some-id" bold>
+      Text
+    </Text>
+  ),
+};

--- a/src/stories/Text.stories.tsx
+++ b/src/stories/Text.stories.tsx
@@ -327,4 +327,3 @@ export const CustomDataAttribute: Story = {
     </Text>
   ),
 };
-

--- a/src/stories/TextArea.stories.tsx
+++ b/src/stories/TextArea.stories.tsx
@@ -32,3 +32,10 @@ export const IdInvalid: Story = {
     return <TextArea value={'wrong\nvalue'} isInvalid />;
   },
 };
+
+export const CustomDataAttribute: Story = {
+  args: {
+    'data-test-id': 'textarea-custom-attribute',
+  },
+  render: (args) => <TextArea {...args} value="This is a text area with a custom data attribute." />,
+};

--- a/src/stories/Toggle.stories.tsx
+++ b/src/stories/Toggle.stories.tsx
@@ -21,3 +21,10 @@ export const Disabled: Story = {
     disabled: true,
   },
 };
+
+export const CustomDataAttribute: Story = {
+  args: {
+    'data-test-id': 'toggle-custom-attribute',
+  },
+  render: (args) => <Toggle {...args} />,
+};

--- a/src/types/attributes.ts
+++ b/src/types/attributes.ts
@@ -1,0 +1,6 @@
+export type CustomDataAttributeProps = {
+  /**
+   * data-*属性
+   */
+  [key: `data-${string}`]: unknown;
+};


### PR DESCRIPTION
# Overview

- Allows custom data attributes to be specified
- Additional examples specified in Stories.
- The props that are not explicit in the component are received together and given to the element together with the spread operator