### PR TITLE
Improve <Heading> Props

### DIFF
--- a/src/components/Heading/Heading.module.css
+++ b/src/components/Heading/Heading.module.css
@@ -1,11 +1,15 @@
 .heading {
-  font-weight: bold;
+  font-weight: normal;
   box-sizing: border-box;
   color: var(--color-text-main);
   position: relative;
 
   --medium-leading-border-width: 4px;
   --large-leading-border-width: 5px;
+}
+
+.heading.bold {
+  font-weight: bold;
 }
 
 :where(.heading) {

--- a/src/components/Heading/Heading.module.css
+++ b/src/components/Heading/Heading.module.css
@@ -28,7 +28,7 @@
   text-align: right;
 }
 
-.heading.secondary {
+.heading.main {
   color: var(--color-text-main);
 }
 

--- a/src/components/Heading/Heading.tsx
+++ b/src/components/Heading/Heading.tsx
@@ -1,5 +1,8 @@
 import { clsx } from 'clsx';
 import styles from './Heading.module.css';
+import {
+  TextColor,
+} from '../../types/style';
 import { HTMLTagname } from '../../utils/types';
 import type { FC, PropsWithChildren, ReactNode } from 'react';
 
@@ -40,7 +43,7 @@ type Props = {
    * テキストのカラーバリエーション
    * @default secondary
    */
-  variant?: 'primary' | 'secondary' | 'accent' | 'white';
+  color?: Extract<TextColor, 'main' | 'primary' | 'accent' | 'white'>;
   /**
    * HTMLのID属性
    */
@@ -63,7 +66,7 @@ const Heading: FC<PropsWithChildren<Props>> = ({
   accentIcon,
   whiteIcon,
   size = 'md',
-  variant = 'secondary',
+  color = 'main',
   leadingBorder,
   as: HeadingComponent = 'p',
   id,

--- a/src/components/Heading/Heading.tsx
+++ b/src/components/Heading/Heading.tsx
@@ -60,7 +60,7 @@ type Props = {
 };
 
 const Heading: FC<PropsWithChildren<Props>> = ({
-  textAlign = 'left',
+  textAlign,
   children,
   primaryIcon,
   accentIcon,
@@ -76,7 +76,7 @@ const Heading: FC<PropsWithChildren<Props>> = ({
   const className = clsx(
     styles.heading,
     primaryIcon || accentIcon || whiteIcon ? styles.hasIcon : null,
-    styles[textAlign],
+    textAlign? styles[textAlign] : null,
     styles[size],
     // For leadingBorder, only the main text colour is supported.
     leadingBorder ? styles.secondary : styles[color],

--- a/src/components/Heading/Heading.tsx
+++ b/src/components/Heading/Heading.tsx
@@ -49,6 +49,11 @@ type Props = {
    * HTMLのfor属性。label要素の場合に使用
    */
   htmlFor?: string;
+  /**
+   * 太字とするかどうか、falseの場合はnormal
+   * @default true
+   */
+  bold?: boolean;
 };
 
 const Heading: FC<PropsWithChildren<Props>> = ({
@@ -63,14 +68,17 @@ const Heading: FC<PropsWithChildren<Props>> = ({
   as: HeadingComponent = 'p',
   id,
   htmlFor,
+  bold = true,
 }) => {
   const className = clsx(
     styles.heading,
     primaryIcon || accentIcon || whiteIcon ? styles.hasIcon : null,
     styles[textAlign],
     styles[size],
-    leadingBorder ? styles.secondary : styles[variant],
+    // For leadingBorder, only the main text colour is supported.
+    leadingBorder ? styles.secondary : styles[color],
     leadingBorder ? styles.leadingBorder : null,
+    bold ? styles.bold : null
   );
 
   return (

--- a/src/components/Heading/Heading.tsx
+++ b/src/components/Heading/Heading.tsx
@@ -1,8 +1,6 @@
 import { clsx } from 'clsx';
 import styles from './Heading.module.css';
-import {
-  TextColor,
-} from '../../types/style';
+import { TextColor } from '../../types/style';
 import { HTMLTagname } from '../../utils/types';
 import type { FC, PropsWithChildren, ReactNode } from 'react';
 
@@ -76,12 +74,12 @@ const Heading: FC<PropsWithChildren<Props>> = ({
   const className = clsx(
     styles.heading,
     primaryIcon || accentIcon || whiteIcon ? styles.hasIcon : null,
-    textAlign? styles[textAlign] : null,
+    textAlign ? styles[textAlign] : null,
     styles[size],
     // For leadingBorder, only the main text colour is supported.
     leadingBorder ? styles.secondary : styles[color],
     leadingBorder ? styles.leadingBorder : null,
-    bold ? styles.bold : null
+    bold ? styles.bold : null,
   );
 
   return (

--- a/src/stories/Heading.stories.tsx
+++ b/src/stories/Heading.stories.tsx
@@ -175,14 +175,18 @@ export const LeadingBorder: Story = {
 export const TextAlign: Story = {
   render: () => (
     <Stack spacing="md" alignItems="normal">
+      <Heading as="p" size="md">
+        スマートフォン問診（inherit）
+      </Heading>
+
       <Heading as="p" size="md" textAlign="left">
-        スマートフォン問診
+        スマートフォン問診（left）
       </Heading>
       <Heading as="p" size="md" textAlign="center">
-        スマートフォン問診
+        スマートフォン問診（center）
       </Heading>
       <Heading as="p" size="md" textAlign="right">
-        スマートフォン問診
+        スマートフォン問診（right）
       </Heading>
     </Stack>
   ),

--- a/src/stories/Heading.stories.tsx
+++ b/src/stories/Heading.stories.tsx
@@ -77,7 +77,7 @@ export const Element: Story = {
   ),
 };
 
-export const colors: Story = {
+export const Colors: Story = {
   render: () => (
     <Stack spacing="md">
       <Heading as="p" color="main" size="md">

--- a/src/stories/Heading.stories.tsx
+++ b/src/stories/Heading.stories.tsx
@@ -48,52 +48,52 @@ export const Default: Story = {
 export const Element: Story = {
   render: () => (
     <Stack spacing="md">
-      <Heading as="p" variant="secondary" size="md">
+      <Heading as="p" color="main" size="md">
         p
       </Heading>
-      <Heading as="h1" variant="secondary" size="md" id="test-id">
+      <Heading as="h1" color="main" size="md" id="test-id">
         h1 with id attribute
       </Heading>
-      <Heading as="h2" variant="secondary" size="md">
+      <Heading as="h2" color="main" size="md">
         h2
       </Heading>
-      <Heading as="h3" variant="secondary" size="md">
+      <Heading as="h3" color="main" size="md">
         h3
       </Heading>
-      <Heading as="h4" variant="secondary" size="md">
+      <Heading as="h4" color="main" size="md">
         h4
       </Heading>
-      <Heading as="h5" variant="secondary" size="md">
+      <Heading as="h5" color="main" size="md">
         h5
       </Heading>
-      <Heading as="h6" variant="secondary" size="md">
+      <Heading as="h6" color="main" size="md">
         h6
       </Heading>
       {/* markuplint-disable-next-line */}
-      <Heading as="label" variant="secondary" size="md" htmlFor="some-input-id">
+      <Heading as="label" color="main" size="md" htmlFor="some-input-id">
         label
       </Heading>
     </Stack>
   ),
 };
 
-export const Variants: Story = {
+export const colors: Story = {
   render: () => (
     <Stack spacing="md">
-      <Heading as="p" variant="secondary" size="md">
-        スマートフォン問診（secondary）
+      <Heading as="p" color="main" size="md">
+        スマートフォン問診（main）
       </Heading>
 
-      <Heading as="p" variant="primary" size="md">
+      <Heading as="p" color="primary" size="md">
         スマートフォン問診（primary）
       </Heading>
 
-      <Heading as="p" variant="accent" size="md">
+      <Heading as="p" color="accent" size="md">
         スマートフォン問診（accent）
       </Heading>
 
       <div style={{ backgroundColor: 'var(--color-primary)', padding: 'var(--size-spacing-xs)' }}>
-        <Heading as="p" variant="white" size="md">
+        <Heading as="p" color="white" size="md">
           スマートフォン問診（white）
         </Heading>
       </div>
@@ -104,20 +104,20 @@ export const Variants: Story = {
 export const HasLink: Story = {
   render: () => (
     <Stack spacing="md">
-      <Heading as="p" variant="secondary" size="md">
-        <a href="https://vitals.ubie.life/">Vitals</a> スマートフォン問診（secondary）
+      <Heading as="p" color="main" size="md">
+        <a href="https://vitals.ubie.life/">Vitals</a> スマートフォン問診（main）
       </Heading>
 
-      <Heading as="p" variant="primary" size="md">
+      <Heading as="p" color="primary" size="md">
         <a href="https://vitals.ubie.life/">Vitals</a> スマートフォン問診（primary）
       </Heading>
 
-      <Heading as="p" variant="accent" size="md">
+      <Heading as="p" color="accent" size="md">
         <a href="https://vitals.ubie.life/">Vitals</a> スマートフォン問診（accent）
       </Heading>
 
       <div style={{ backgroundColor: 'var(--color-primary)', padding: 'var(--size-spacing-xs)' }}>
-        <Heading as="p" variant="white" size="md">
+        <Heading as="p" color="white" size="md">
           <a href="https://vitals.ubie.life/">Vitals</a> スマートフォン問診（white）
         </Heading>
       </div>
@@ -250,23 +250,36 @@ export const Icon: Story = {
 
       <div style={{ backgroundColor: 'var(--color-primary)', padding: 'var(--size-spacing-xs)' }}>
         <Stack spacing="md">
-          <Heading as="p" variant="white" whiteIcon={<SetupIcon />} size="xs">
+          <Heading as="p" color="white" whiteIcon={<SetupIcon />} size="xs">
             スマートフォン問診
           </Heading>
-          <Heading as="p" variant="white" whiteIcon={<SetupIcon />} size="sm">
+          <Heading as="p" color="white" whiteIcon={<SetupIcon />} size="sm">
             スマートフォン問診
           </Heading>
-          <Heading as="p" variant="white" whiteIcon={<SetupIcon />} size="md">
+          <Heading as="p" color="white" whiteIcon={<SetupIcon />} size="md">
             スマートフォン問診
           </Heading>
-          <Heading as="p" variant="white" whiteIcon={<SetupIcon />} size="lg">
+          <Heading as="p" color="white" whiteIcon={<SetupIcon />} size="lg">
             スマートフォン問診
           </Heading>
-          <Heading as="p" variant="white" whiteIcon={<SetupIcon />} size="xl">
+          <Heading as="p" color="white" whiteIcon={<SetupIcon />} size="xl">
             スマートフォン問診
           </Heading>
         </Stack>
       </div>
+    </Stack>
+  ),
+};
+
+export const Bold: Story = {
+  render: () => (
+    <Stack spacing="md">
+      <Heading as="h1" color="main" size="md">
+        h1 bold
+      </Heading>
+      <Heading as="h1" color="main" size="md" bold={false}>
+        h1 normal
+      </Heading>
     </Stack>
   ),
 };

--- a/src/utils/style.spec.ts
+++ b/src/utils/style.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { opacityToClassName } from './style';
+import { opacityToClassName, colorVariable } from './style';
 
 describe('opacityToClassName', () => {
   it('shuold return normalOverlay when opacity is normal', () => {
@@ -10,3 +10,37 @@ describe('opacityToClassName', () => {
     expect(opacityToClassName('darker')).toBe('darkerOverlay');
   });
 });
+
+
+describe('craeteTextColorVariable', () => {
+  it('should return main text color variable', () =>{
+    expect(colorVariable('main')).toStrictEqual({
+      '--text-color': 'var(--color-text-main)'
+    })
+  })
+  it('should return sub text color variable', () =>{
+    expect(colorVariable('sub')).toStrictEqual({
+      '--text-color': 'var(--color-text-sub)'
+    })
+  })
+  it('should return primary color variable', () =>{
+    expect(colorVariable('primary')).toStrictEqual({
+      '--text-color': 'var(--color-primary)'
+    })
+  })
+  it('should return accent color variable', () =>{
+    expect(colorVariable('accent')).toStrictEqual({
+      '--text-color': 'var(--color-accent)'
+    })
+  })
+  it('should return alert color variable', () =>{
+    expect(colorVariable('alert')).toStrictEqual({
+      '--text-color': 'var(--color-alert)'
+    })
+  })
+  it('should return link sub text color variable', () =>{
+    expect(colorVariable('linkSub')).toStrictEqual({
+      '--text-color': 'var(--color-text-link-sub)'
+    })
+  })
+})

--- a/src/utils/style.spec.ts
+++ b/src/utils/style.spec.ts
@@ -11,36 +11,35 @@ describe('opacityToClassName', () => {
   });
 });
 
-
 describe('craeteTextColorVariable', () => {
-  it('should return main text color variable', () =>{
+  it('should return main text color variable', () => {
     expect(colorVariable('main')).toStrictEqual({
-      '--text-color': 'var(--color-text-main)'
-    })
-  })
-  it('should return sub text color variable', () =>{
+      '--text-color': 'var(--color-text-main)',
+    });
+  });
+  it('should return sub text color variable', () => {
     expect(colorVariable('sub')).toStrictEqual({
-      '--text-color': 'var(--color-text-sub)'
-    })
-  })
-  it('should return primary color variable', () =>{
+      '--text-color': 'var(--color-text-sub)',
+    });
+  });
+  it('should return primary color variable', () => {
     expect(colorVariable('primary')).toStrictEqual({
-      '--text-color': 'var(--color-primary)'
-    })
-  })
-  it('should return accent color variable', () =>{
+      '--text-color': 'var(--color-primary)',
+    });
+  });
+  it('should return accent color variable', () => {
     expect(colorVariable('accent')).toStrictEqual({
-      '--text-color': 'var(--color-accent)'
-    })
-  })
-  it('should return alert color variable', () =>{
+      '--text-color': 'var(--color-accent)',
+    });
+  });
+  it('should return alert color variable', () => {
     expect(colorVariable('alert')).toStrictEqual({
-      '--text-color': 'var(--color-alert)'
-    })
-  })
-  it('should return link sub text color variable', () =>{
+      '--text-color': 'var(--color-alert)',
+    });
+  });
+  it('should return link sub text color variable', () => {
     expect(colorVariable('linkSub')).toStrictEqual({
-      '--text-color': 'var(--color-text-link-sub)'
-    })
-  })
-})
+      '--text-color': 'var(--color-text-link-sub)',
+    });
+  });
+});


### PR DESCRIPTION
# Overview

- variant prop -> color prop(Match Text components and tokens.)
- `text-align: inherit` support
  - For use in combination with <Center>
- `font-weight: normal` is supported.

# Screenshot

![スクリーンショット 2024-05-09 13 49 19](https://github.com/ubie-oss/ubie-ui/assets/10903851/3f94bc7a-ddea-48ed-8179-95e5be7269c6)
![スクリーンショット 2024-05-09 13 49 15](https://github.com/ubie-oss/ubie-ui/assets/10903851/bab12dfc-09e0-458f-8115-14d4a44bc7de)
![スクリーンショット 2024-05-09 13 49 06](https://github.com/ubie-oss/ubie-ui/assets/10903851/26c7c55d-e81f-4642-aebc-fe62512c9034)
