### PR TITLE
chore: update heading font size to medium in Text module

### DIFF
--- a/src/components/Text/Text.module.css
+++ b/src/components/Text/Text.module.css
@@ -36,7 +36,7 @@
 }
 
 .heading.md {
-  --font-size: var(--text-heading-sm-size);
+  --font-size: var(--text-heading-md-size);
 }
 
 .heading.lg {


### PR DESCRIPTION
Textコンポーネントのmdがsmと同じで`var(--text-heading-sm-size);`になっていたので修正