### PR TITLE
Add text align prop to `<Box>` and `<Text>`

### DIFF
--- a/src/components/Box/Box.module.css
+++ b/src/components/Box/Box.module.css
@@ -65,3 +65,15 @@
 .box.textNormal {
   font-weight: normal;
 }
+
+.box.textCenter {
+  text-align: center;
+}
+
+.box.textLeft {
+  text-align: left;
+}
+
+.box.textRight {
+  text-align: right;
+}

--- a/src/components/Box/Box.tsx
+++ b/src/components/Box/Box.tsx
@@ -49,9 +49,13 @@ type BaseProps = {
    */
   textBold?: boolean;
   /**
-   * 文字色の抽象値。のかのtext系Propとは独立して指定可能
+   * 文字色の抽象値
    */
   textColor?: TextColor;
+  /**
+   * テキストの配置。指定しない場合、親要素の配置を継承
+   */
+  textAlign?: 'left' | 'center' | 'right';
 } & PaddingProps &
   MarginProps &
   RadiusProp;
@@ -171,6 +175,7 @@ export const Box: FC<PropsWithChildren<PropsWithoutText | PropsWithTextBody | Pr
   textLeading,
   textColor,
   textBold,
+  textAlign,
 }) => {
   let _textVariables: CSSProperties = {};
 
@@ -189,6 +194,7 @@ export const Box: FC<PropsWithChildren<PropsWithoutText | PropsWithTextBody | Pr
         width && styles.widthFull,
         textBold && styles.textBold,
         textBold === false && styles.textNormal,
+        textAlign && styles[`text${capitalize(textAlign)}`],
       ])}
       style={{
         ...paddingVariables({

--- a/src/components/Heading/Heading.tsx
+++ b/src/components/Heading/Heading.tsx
@@ -6,8 +6,7 @@ import type { FC, PropsWithChildren, ReactNode } from 'react';
 
 type Props = {
   /**
-   * テキストの配置
-   * @default left
+   * テキストの配置。指定しない場合、親要素の配置を継承
    */
   textAlign?: 'left' | 'center' | 'right';
   /**

--- a/src/components/Text/Text.module.css
+++ b/src/components/Text/Text.module.css
@@ -151,3 +151,15 @@
 .white {
   --color: var(--color-text-white);
 }
+
+.left {
+  text-align: left;
+}
+
+.center {
+  text-align: center;
+}
+
+.right {
+  text-align: right;
+}

--- a/src/components/Text/Text.tsx
+++ b/src/components/Text/Text.tsx
@@ -42,6 +42,10 @@ type BaseProps = {
    * HTMLのid属性
    */
   id?: string;
+  /**
+   * テキストの配置。指定しない場合、親要素の配置を継承
+   */
+  textAlign?: 'left' | 'center' | 'right';
 };
 
 type BodyProps = BaseProps & {
@@ -139,11 +143,20 @@ export const Text: FC<TextProps> = ({
   color = 'main',
   children,
   id,
+  textAlign,
 }) => {
   return (
     <TextComponent
       id={id}
-      className={clsx(styles.text, bold && styles.bold, styles[size], styles[type], styles[leading], styles[color])}
+      className={clsx(
+        styles.text,
+        bold && styles.bold,
+        styles[size],
+        styles[type],
+        styles[leading],
+        styles[color],
+        textAlign && styles[textAlign],
+      )}
     >
       {children}
     </TextComponent>

--- a/src/stories/Box.stories.tsx
+++ b/src/stories/Box.stories.tsx
@@ -298,9 +298,21 @@ export const TextVariations: Story = {
       <Box {...defaultArgs} mt="md" textType="note" textSize="lg" textLeading="narrow">
         <p>Note Large Narrow</p>
       </Box>
-      <Box {...defaultArgs} mt="md" textType="note" textSize="lg" textLeading="tight">
-        <p>Note Large Tight</p>
+
+      <Box {...defaultArgs} mt="xl" textAlign="left">
+        <p>Text Left</p>
       </Box>
+      <Box {...defaultArgs} mt="md" textAlign="center">
+        <p>Text Center</p>
+      </Box>
+      <Box {...defaultArgs} mt="md" textAlign="right">
+        <p>Text Right</p>
+      </Box>
+      <div style={{ textAlign: 'center' }}>
+        <Box {...defaultArgs} mt="md">
+          <p>Inherit(undefined)</p>
+        </Box>
+      </div>
     </div>
   ),
 };

--- a/src/stories/Heading.stories.tsx
+++ b/src/stories/Heading.stories.tsx
@@ -175,9 +175,11 @@ export const LeadingBorder: Story = {
 export const TextAlign: Story = {
   render: () => (
     <Stack spacing="md" alignItems="normal">
-      <Heading as="p" size="md">
-        スマートフォン問診（inherit）
-      </Heading>
+      <div style={{ textAlign: 'center' }}>
+        <Heading as="p" size="md">
+          スマートフォン問診（inherit）
+        </Heading>
+      </div>
 
       <Heading as="p" size="md" textAlign="left">
         スマートフォン問診（left）

--- a/src/stories/Text.stories.tsx
+++ b/src/stories/Text.stories.tsx
@@ -306,3 +306,21 @@ export const TextInText: Story = {
     </Text>
   ),
 };
+
+export const Align: Story = {
+  render: () => (
+    <Stack spacing='md' alignItems='normal'>
+      <Text textAlign='left'>Left
+      </Text>
+      <Text textAlign='center'>Center
+      </Text>
+      <Text textAlign='right'>Right
+      </Text>
+      <div style={{ textAlign: 'center' }}>
+      <Text textAlign='center'>Inherit(undefined)
+      </Text>
+      </div>
+    </Stack>
+  ),
+};
+

--- a/src/stories/Text.stories.tsx
+++ b/src/stories/Text.stories.tsx
@@ -309,18 +309,13 @@ export const TextInText: Story = {
 
 export const Align: Story = {
   render: () => (
-    <Stack spacing='md' alignItems='normal'>
-      <Text textAlign='left'>Left
-      </Text>
-      <Text textAlign='center'>Center
-      </Text>
-      <Text textAlign='right'>Right
-      </Text>
+    <Stack spacing="md" alignItems="normal">
+      <Text textAlign="left">Left</Text>
+      <Text textAlign="center">Center</Text>
+      <Text textAlign="right">Right</Text>
       <div style={{ textAlign: 'center' }}>
-      <Text textAlign='center'>Inherit(undefined)
-      </Text>
+        <Text textAlign="center">Inherit(undefined)</Text>
       </div>
     </Stack>
   ),
 };
-

--- a/src/stories/Text.stories.tsx
+++ b/src/stories/Text.stories.tsx
@@ -307,7 +307,7 @@ export const TextInText: Story = {
   ),
 };
 
-export const Align: Story = {
+export const TextAlign: Story = {
   render: () => (
     <Stack spacing="md" alignItems="normal">
       <Text textAlign="left">Left</Text>


### PR DESCRIPTION
# Motivation

- I want to specify `align` as a text setting
- I want to implement the same prop as for heading in other components

# Screenshots

## `<Box>`

![スクリーンショット 2024-05-13 11 12 25](https://github.com/ubie-oss/ubie-ui/assets/10903851/7520b54c-ec23-45d3-9891-e25eb79ec2b8)

## `<Text>`

![スクリーンショット 2024-05-13 11 12 38](https://github.com/ubie-oss/ubie-ui/assets/10903851/6628f999-ad75-4d65-8972-b1fec6af6aea)
