### PR TITLE
Layout as box

### DIFF
--- a/src/components/Center/Center.tsx
+++ b/src/components/Center/Center.tsx
@@ -1,18 +1,20 @@
 'use client';
 
 import clsx from 'clsx';
+import { isValidElement, cloneElement } from 'react';
 import styles from './Center.module.css';
 import { createSpacingVariableFromKey, paddingVariables } from '../../utils/style';
 import { HTMLTagname } from '../../utils/types';
+import { Box } from '../Box/Box';
 import type { MarginYProps, PaddingProps } from '../../types/style';
-import type { FC, PropsWithChildren, CSSProperties } from 'react';
+import type { FC, PropsWithChildren, CSSProperties, ComponentType, ReactElement, ReactNode } from 'react';
 
 type Props = {
   /**
    * レンダリングされるHTML要素
    * @default div
    */
-  as?: HTMLTagname;
+  as?: HTMLTagname | ReactElement<ComponentType<typeof Box>>;
   /**
    * 内包するテキストを中央に配置。設定は継承され、子孫要素にも影響します
    * @default false
@@ -49,27 +51,37 @@ export const Center: FC<PropsWithChildren<Props>> = ({
   id,
   maxWidth = 'none',
 }) => {
-  return (
-    <CenterCopmonent
-      id={id}
-      className={clsx(styles.center, textCenter && styles.textCenter, childrenCenter && styles.childrenCenter)}
-      style={
-        {
-          '--max-width': maxWidth,
-          ...paddingVariables({
-            pt,
-            pr,
-            pb,
-            pl,
-          }),
-          ...{
-            '--margin-top': mt ? createSpacingVariableFromKey(mt) : 0,
-            '--margin-bottom': mb ? createSpacingVariableFromKey(mb) : 0,
-          },
-        } as CSSProperties
-      }
-    >
-      {children}
-    </CenterCopmonent>
+  /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
+  const createElement = (props: any, children: ReactNode) => {
+    if (isValidElement(CenterCopmonent)) {
+      return (
+          <div {...props}>
+            {cloneElement(CenterCopmonent, CenterCopmonent.props, children)}
+          </div>
+      )
+    } else {
+      return <CenterCopmonent {...props}>{children}</CenterCopmonent>;
+    }
+};
+
+  return createElement(
+    {
+      id,
+      className: clsx(styles.center, textCenter && styles.textCenter, childrenCenter && styles.childrenCenter),
+      style: {
+        '--max-width': maxWidth,
+        ...paddingVariables({
+          pt,
+          pr,
+          pb,
+          pl,
+        }),
+        ...{
+          '--margin-top': mt ? createSpacingVariableFromKey(mt) : 0,
+          '--margin-bottom': mb ? createSpacingVariableFromKey(mb) : 0,
+        },
+      } as CSSProperties,
+    },
+    children,
   );
 };

--- a/src/components/Center/Center.tsx
+++ b/src/components/Center/Center.tsx
@@ -54,15 +54,11 @@ export const Center: FC<PropsWithChildren<Props>> = ({
   /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
   const createElement = (props: any, children: ReactNode) => {
     if (isValidElement(CenterCopmonent)) {
-      return (
-          <div {...props}>
-            {cloneElement(CenterCopmonent, CenterCopmonent.props, children)}
-          </div>
-      )
+      return <div {...props}>{cloneElement(CenterCopmonent, CenterCopmonent.props, children)}</div>;
     } else {
       return <CenterCopmonent {...props}>{children}</CenterCopmonent>;
     }
-};
+  };
 
   return createElement(
     {

--- a/src/components/Flex/Flex.tsx
+++ b/src/components/Flex/Flex.tsx
@@ -1,19 +1,21 @@
 'use client';
 
 import clsx from 'clsx';
+import { isValidElement, cloneElement } from 'react';
 import styles from './Flex.module.css';
 import { Spacing, AlignItems, JustifyContent, FlexDirection } from '../../types/style';
 import { paddingVariables, marginVariables } from '../../utils/style';
 import { HTMLTagname } from '../../utils/types';
+import { Box } from '../Box/Box';
 import type { PaddingProps, MarginProps } from '../../types/style';
-import type { FC, PropsWithChildren } from 'react';
+import type { FC, PropsWithChildren, ReactElement, ComponentType, ReactNode } from 'react';
 
 type Props = {
   /**
    * レンダリングされるHTML要素
    * @default div
    */
-  as?: HTMLTagname;
+  as?: HTMLTagname | ReactElement<ComponentType<typeof Box>>;
   /**
    * 子要素同士の間隔
    */
@@ -43,7 +45,7 @@ type Props = {
    */
   height?: 'full';
   /**
-   * デフォルトで<Flex>は横幅いっぱいを専有する。しかし例えば、フレックスコンテナの子要素として配置した場合、横幅が自身の子に合わせて小さくなる。これが不都合の場合に100%とする事が可能
+   * デフォルト<Flex>は横幅いっぱいを専有する。しかし例えば、フレックスコンテナの子要素として配置した場合、横幅が自身の子に合わせて小さくなる。これが不都合の場合に100%とする事が可能
    */
   width?: 'full';
 } & MarginProps &
@@ -71,32 +73,46 @@ export const Flex: FC<PropsWithChildren<Props>> = ({
   // Directly specifying the markuplint will result in a markuplint error.
   const gapStyle = spacing ? `var(--size-spacing-${spacing})` : '0';
 
-  return (
-    <FlexCopmonent
-      className={clsx(styles.flex, height === 'full' && styles.heightFull, width === 'full' && styles.widthFull)}
-      style={
-        {
-          '--gap': gapStyle,
-          '--flex-direction': direction,
-          '--align-items': alignItems,
-          '--justify-content': justifyContent,
-          '--flex-wrap': wrap ? 'wrap' : 'nowrap',
-          ...paddingVariables({
-            pt,
-            pr,
-            pb,
-            pl,
-          }),
-          ...marginVariables({
-            mt,
-            mr,
-            mb,
-            ml,
-          }),
-        } as React.CSSProperties
+  /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
+  const createElement = (props: any, children: ReactNode) => {
+      if (isValidElement(FlexCopmonent)) {
+        return cloneElement(
+          FlexCopmonent,
+          FlexCopmonent.props,
+          (
+            <div {...props}>
+              {children}
+            </div>
+          )
+        )
+      } else {
+        return <FlexCopmonent {...props}>{children}</FlexCopmonent>;
       }
-    >
-      {children}
-    </FlexCopmonent>
+  };
+
+  return createElement(
+    {
+      className: clsx(styles.flex, height === 'full' && styles.heightFull, width === 'full' && styles.widthFull),
+      style: {
+        '--gap': gapStyle,
+        '--flex-direction': direction,
+        '--align-items': alignItems,
+        '--justify-content': justifyContent,
+        '--flex-wrap': wrap ? 'wrap' : 'nowrap',
+        ...paddingVariables({
+          pt,
+          pr,
+          pb,
+          pl,
+        }),
+        ...marginVariables({
+          mt,
+          mr,
+          mb,
+          ml,
+        }),
+      },
+    },
+    children,
   );
 };

--- a/src/components/Flex/Flex.tsx
+++ b/src/components/Flex/Flex.tsx
@@ -75,19 +75,11 @@ export const Flex: FC<PropsWithChildren<Props>> = ({
 
   /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
   const createElement = (props: any, children: ReactNode) => {
-      if (isValidElement(FlexCopmonent)) {
-        return cloneElement(
-          FlexCopmonent,
-          FlexCopmonent.props,
-          (
-            <div {...props}>
-              {children}
-            </div>
-          )
-        )
-      } else {
-        return <FlexCopmonent {...props}>{children}</FlexCopmonent>;
-      }
+    if (isValidElement(FlexCopmonent)) {
+      return cloneElement(FlexCopmonent, FlexCopmonent.props, <div {...props}>{children}</div>);
+    } else {
+      return <FlexCopmonent {...props}>{children}</FlexCopmonent>;
+    }
   };
 
   return createElement(

--- a/src/components/Stack/Stack.tsx
+++ b/src/components/Stack/Stack.tsx
@@ -1,19 +1,21 @@
 'use client';
 
 import { clsx } from 'clsx';
-import { FC, ReactNode } from 'react';
+import { isValidElement, cloneElement } from 'react';
 import styles from './Stack.module.css';
 import { Spacing, AlignItems, JustifyContent } from '../../types/style';
 import { paddingVariables, marginVariables } from '../../utils/style';
 import { HTMLTagname } from '../../utils/types';
+import { Box } from '../Box/Box';
 import type { PaddingProps, MarginProps } from '../../types/style';
+import type { FC, ReactNode, ComponentType, ReactElement } from 'react';
 
 type Props = {
   /**
    * レンダリングされるコンポーネントまたはHTML要素
    * @default div
    */
-  as?: HTMLTagname;
+  as?: HTMLTagname | ReactElement<ComponentType<typeof Box>>;
   /**
    * 子要素の間隔
    */
@@ -60,9 +62,27 @@ export const Stack: FC<Props> = ({
   mb,
   ml,
 }) => {
-  return (
-    <StackComponent
-      style={{
+  /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
+  const createElement = (props: any, children: ReactNode) => {
+      if (isValidElement(StackComponent)) {
+        return cloneElement(
+          StackComponent,
+          StackComponent.props,
+          (
+            <div {...props}>
+              {children}
+            </div>
+          )
+        )
+      } else {
+        return <StackComponent {...props}>{children}</StackComponent>;
+      }
+  };
+
+  return createElement(
+    {
+      className: clsx(className, styles.stack),
+      style: {
         alignItems: `${alignItems}`,
         justifyContent: `${justifyContent}`,
         gap: `var(--size-spacing-${spacing})`,
@@ -78,10 +98,8 @@ export const Stack: FC<Props> = ({
           mb,
           ml,
         }),
-      }}
-      className={clsx(className, styles.stack)}
-    >
-      {children}
-    </StackComponent>
+      },
+    },
+    children
   );
 };

--- a/src/components/Stack/Stack.tsx
+++ b/src/components/Stack/Stack.tsx
@@ -64,19 +64,11 @@ export const Stack: FC<Props> = ({
 }) => {
   /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
   const createElement = (props: any, children: ReactNode) => {
-      if (isValidElement(StackComponent)) {
-        return cloneElement(
-          StackComponent,
-          StackComponent.props,
-          (
-            <div {...props}>
-              {children}
-            </div>
-          )
-        )
-      } else {
-        return <StackComponent {...props}>{children}</StackComponent>;
-      }
+    if (isValidElement(StackComponent)) {
+      return cloneElement(StackComponent, StackComponent.props, <div {...props}>{children}</div>);
+    } else {
+      return <StackComponent {...props}>{children}</StackComponent>;
+    }
   };
 
   return createElement(
@@ -100,6 +92,6 @@ export const Stack: FC<Props> = ({
         }),
       },
     },
-    children
+    children,
   );
 };

--- a/src/stories/Box.stories.tsx
+++ b/src/stories/Box.stories.tsx
@@ -23,135 +23,140 @@ export const Default: Story = {
 };
 
 export const BackgroundColor: Story = {
-  render: () => (
+  render: (args) => (
     <div>
-      <Box {...defaultArgs} backgroundColor="primary">
+      <Box {...args} backgroundColor="primary">
         Primary
       </Box>
-      <Box {...defaultArgs} mt="md" backgroundColor="primaryDarken">
+      <Box {...args} mt="md" backgroundColor="primaryDarken">
         Primary Darken
       </Box>
-      <Box {...defaultArgs} mt="md" backgroundColor="accent">
+      <Box {...args} mt="md" backgroundColor="accent">
         Accent
       </Box>
-      <Box {...defaultArgs} mt="md" backgroundColor="accentDarken">
+      <Box {...args} mt="md" backgroundColor="accentDarken">
         Accent Darken
       </Box>
-      <Box {...defaultArgs} mt="md" backgroundColor="alert">
+      <Box {...args} mt="md" backgroundColor="alert">
         Alert
       </Box>
-      <Box {...defaultArgs} mt="md" backgroundColor="gray">
+      <Box {...args} mt="md" backgroundColor="gray">
         Gray
       </Box>
-      <Box {...defaultArgs} mt="md" backgroundColor="white">
+      <Box {...args} mt="md" backgroundColor="white">
         White
       </Box>
     </div>
   ),
+  args: defaultArgs,
 };
 
 export const Padding: Story = {
-  render: () => (
+  render: (args) => (
     <div>
-      <Box {...defaultArgs} pt="xxs" pr="xxs" pb="xxs" pl="xxs">
+      <Box {...args} pt="xxs" pr="xxs" pb="xxs" pl="xxs">
         xxs
       </Box>
-      <Box {...defaultArgs} mt="md" pt="xs" pr="xs" pb="xs" pl="xs">
+      <Box {...args} mt="md" pt="xs" pr="xs" pb="xs" pl="xs">
         xs
       </Box>
-      <Box {...defaultArgs} mt="md" pt="sm" pr="sm" pb="sm" pl="sm">
+      <Box {...args} mt="md" pt="sm" pr="sm" pb="sm" pl="sm">
         sm
       </Box>
-      <Box {...defaultArgs} mt="md" pt="md" pr="md" pb="md" pl="md">
+      <Box {...args} mt="md" pt="md" pr="md" pb="md" pl="md">
         md
       </Box>
-      <Box {...defaultArgs} mt="md" pt="lg" pr="lg" pb="lg" pl="lg">
+      <Box {...args} mt="md" pt="lg" pr="lg" pb="lg" pl="lg">
         lg
       </Box>
-      <Box {...defaultArgs} mt="md" pt="xl" pr="xl" pb="xl" pl="xl">
+      <Box {...args} mt="md" pt="xl" pr="xl" pb="xl" pl="xl">
         xl
       </Box>
-      <Box {...defaultArgs} mt="md" pt="xxl" pr="xxl" pb="xxl" pl="xxl">
+      <Box {...args} mt="md" pt="xxl" pr="xxl" pb="xxl" pl="xxl">
         xxl
       </Box>
     </div>
   ),
+  args: defaultArgs,
 };
 
 export const Margin: Story = {
-  render: () => (
+  render: (args) => (
     <div>
-      <Box {...defaultArgs} mt="xxs" mr="xxs" mb="xxs" ml="xxs">
+      <Box {...args} mt="xxs" mr="xxs" mb="xxs" ml="xxs">
         xxs
       </Box>
       <hr />
-      <Box {...defaultArgs} mt="xs" mr="xs" mb="xs" ml="xs">
+      <Box {...args} mt="xs" mr="xs" mb="xs" ml="xs">
         xs
       </Box>
       <hr />
-      <Box {...defaultArgs} mt="sm" mr="sm" mb="sm" ml="sm">
+      <Box {...args} mt="sm" mr="sm" mb="sm" ml="sm">
         sm
       </Box>
       <hr />
-      <Box {...defaultArgs} mt="md" mr="md" mb="md" ml="md">
+      <Box {...args} mt="md" mr="md" mb="md" ml="md">
         md
       </Box>
       <hr />
-      <Box {...defaultArgs} mt="lg" mr="lg" mb="lg" ml="lg">
+      <Box {...args} mt="lg" mr="lg" mb="lg" ml="lg">
         lg
       </Box>
       <hr />
-      <Box {...defaultArgs} mt="xl" mr="xl" mb="xl" ml="xl">
+      <Box {...args} mt="xl" mr="xl" mb="xl" ml="xl">
         xl
       </Box>
       <hr />
-      <Box {...defaultArgs} mt="xxl" mr="xxl" mb="xxl" ml="xxl">
+      <Box {...args} mt="xxl" mr="xxl" mb="xxl" ml="xxl">
         xxl
       </Box>
     </div>
   ),
+  args: defaultArgs,
 };
 
 export const Radius: Story = {
-  render: () => (
+  render: (args) => (
     <div>
-      <Box {...defaultArgs} pt="md" pr="md" pb="md" pl="md" radius="xs">
+      <Box {...args} pt="md" pr="md" pb="md" pl="md" radius="xs">
         xs
       </Box>
-      <Box {...defaultArgs} mt="md" pt="md" pr="md" pb="md" pl="md" radius="sm">
+      <Box {...args} mt="md" pt="md" pr="md" pb="md" pl="md" radius="sm">
         sm
       </Box>
-      <Box {...defaultArgs} mt="md" pt="md" pr="md" pb="md" pl="md" radius="md">
+      <Box {...args} mt="md" pt="md" pr="md" pb="md" pl="md" radius="md">
         md
       </Box>
-      <Box {...defaultArgs} mt="md" pt="md" pr="md" pb="md" pl="md" radius="lg">
+      <Box {...args} mt="md" pt="md" pr="md" pb="md" pl="md" radius="lg">
         lg
       </Box>
     </div>
   ),
+  args: defaultArgs,
 };
 
 export const Border: Story = {
-  render: () => (
+  render: (args) => (
     <div>
-      <Box {...defaultArgs} backgroundColor="white" border="gray">
+      <Box {...args} backgroundColor="white" border="gray">
         Border Gray
       </Box>
 
-      <Box {...defaultArgs} backgroundColor="white" border="gray">
+      <Box {...args} backgroundColor="white" border="gray">
         Border Gray
       </Box>
-      <Box mt="md" {...defaultArgs} backgroundColor="white" border="grayThick">
+      <Box mt="md" {...args} backgroundColor="white" border="grayThick">
         Border Gray Thick
       </Box>
-      <Box {...defaultArgs} mt="md" backgroundColor="white" border="primary">
+      <Box {...args} mt="md" backgroundColor="white" border="primary">
         Primary Border
       </Box>
-      <Box {...defaultArgs} mt="md" backgroundColor="white" border="primaryThick">
+      <Box {...args} mt="md" backgroundColor="white" border="primaryThick">
         Primary Border Thick
       </Box>
     </div>
   ),
+  args: defaultArgs,
 };
 
 export const Width: Story = {
@@ -180,10 +185,10 @@ export const AsSection: Story = {
 };
 
 export const TextVariations: Story = {
-  render: () => (
+  render: (args) => (
     <div>
       <Box
-        {...defaultArgs}
+        {...args}
         backgroundColor="gray"
         textColor="primary"
         textBold
@@ -193,12 +198,12 @@ export const TextVariations: Story = {
       >
         <p>Text Bold</p>
 
-        <Box {...defaultArgs} backgroundColor="gray">
+        <Box {...args} backgroundColor="gray">
           <p>nested</p>
         </Box>
 
         <Box
-          {...defaultArgs}
+          {...args}
           mt="md"
           backgroundColor="gray"
           textType="note"
@@ -210,97 +215,98 @@ export const TextVariations: Story = {
         </Box>
       </Box>
 
-      <Box {...defaultArgs} backgroundColor="gray" mt="xl" textColor="main">
+      <Box {...args} backgroundColor="gray" mt="xl" textColor="main">
         <p>Color Main</p>
       </Box>
-      <Box {...defaultArgs} backgroundColor="gray" mt="md" textColor="sub">
+      <Box {...args} backgroundColor="gray" mt="md" textColor="sub">
         <p>Color Sub</p>
       </Box>
-      <Box {...defaultArgs} backgroundColor="gray" mt="md" textColor="link">
+      <Box {...args} backgroundColor="gray" mt="md" textColor="link">
         <p>Color Main</p>
       </Box>
-      <Box {...defaultArgs} backgroundColor="gray" mt="md" textColor="linkSub">
+      <Box {...args} backgroundColor="gray" mt="md" textColor="linkSub">
         <p>Color Link Sub</p>
       </Box>
-      <Box {...defaultArgs} backgroundColor="gray" mt="md" textColor="disabled">
+      <Box {...args} backgroundColor="gray" mt="md" textColor="disabled">
         <p>Color Disabled</p>
       </Box>
-      <Box {...defaultArgs} backgroundColor="gray" mt="md" textColor="primary">
+      <Box {...args} backgroundColor="gray" mt="md" textColor="primary">
         <p>Color Primary</p>
       </Box>
-      <Box {...defaultArgs} backgroundColor="gray" mt="md" textColor="accent">
+      <Box {...args} backgroundColor="gray" mt="md" textColor="accent">
         <p>Color Accent</p>
       </Box>
-      <Box {...defaultArgs} backgroundColor="gray" mt="md" textColor="alert">
+      <Box {...args} backgroundColor="gray" mt="md" textColor="alert">
         <p>Color Alert</p>
       </Box>
-      <Box {...defaultArgs} mt="xl" textType="body">
+      <Box {...args} mt="xl" textType="body">
         <p>Body size & leading default value</p>
       </Box>
 
-      <Box {...defaultArgs} mt="xl" textType="body" textSize="sm" textLeading="default">
+      <Box {...args} mt="xl" textType="body" textSize="sm" textLeading="default">
         <p>Body Small Default</p>
       </Box>
-      <Box {...defaultArgs} mt="md" textType="body" textSize="sm" textLeading="narrow">
+      <Box {...args} mt="md" textType="body" textSize="sm" textLeading="narrow">
         <p>Body Small Narrow</p>
       </Box>
-      <Box {...defaultArgs} mt="md" textType="body" textSize="sm" textLeading="tight">
+      <Box {...args} mt="md" textType="body" textSize="sm" textLeading="tight">
         <p>Body Small Tight</p>
       </Box>
 
-      <Box {...defaultArgs} mt="xl" textType="body" textSize="md" textLeading="default">
+      <Box {...args} mt="xl" textType="body" textSize="md" textLeading="default">
         <p>Body Medium Default</p>
       </Box>
-      <Box {...defaultArgs} mt="md" textType="body" textSize="md" textLeading="narrow">
+      <Box {...args} mt="md" textType="body" textSize="md" textLeading="narrow">
         <p>Body Medium Narrow</p>
       </Box>
-      <Box {...defaultArgs} mt="md" textType="body" textSize="md" textLeading="tight">
+      <Box {...args} mt="md" textType="body" textSize="md" textLeading="tight">
         <p>Body Medium Tight</p>
       </Box>
 
-      <Box {...defaultArgs} mt="xl" textType="body" textSize="lg" textLeading="default">
+      <Box {...args} mt="xl" textType="body" textSize="lg" textLeading="default">
         <p>Body Large Default</p>
       </Box>
-      <Box {...defaultArgs} mt="md" textType="body" textSize="lg" textLeading="narrow">
+      <Box {...args} mt="md" textType="body" textSize="lg" textLeading="narrow">
         <p>Body Large Narrow</p>
       </Box>
-      <Box {...defaultArgs} mt="md" textType="body" textSize="lg" textLeading="tight">
+      <Box {...args} mt="md" textType="body" textSize="lg" textLeading="tight">
         <p>Body Large Tight</p>
       </Box>
 
-      <Box {...defaultArgs} mt="xl" textType="note">
+      <Box {...args} mt="xl" textType="note">
         <p>Note size & leading default value</p>
       </Box>
 
-      <Box {...defaultArgs} mt="xl" textType="note" textSize="sm" textLeading="default">
+      <Box {...args} mt="xl" textType="note" textSize="sm" textLeading="default">
         <p>Note Small Default</p>
       </Box>
-      <Box {...defaultArgs} mt="md" textType="note" textSize="sm" textLeading="narrow">
+      <Box {...args} mt="md" textType="note" textSize="sm" textLeading="narrow">
         <p>Note Small Narrow</p>
       </Box>
-      <Box {...defaultArgs} mt="md" textType="note" textSize="sm" textLeading="tight">
+      <Box {...args} mt="md" textType="note" textSize="sm" textLeading="tight">
         <p>Note Small Tight</p>
       </Box>
 
-      <Box {...defaultArgs} mt="xl" textType="note" textSize="md" textLeading="default">
+      <Box {...args} mt="xl" textType="note" textSize="md" textLeading="default">
         <p>Note Medium Default</p>
       </Box>
-      <Box {...defaultArgs} mt="md" textType="note" textSize="md" textLeading="narrow">
+      <Box {...args} mt="md" textType="note" textSize="md" textLeading="narrow">
         <p>Note Medium Narrow</p>
       </Box>
-      <Box {...defaultArgs} mt="md" textType="note" textSize="md" textLeading="tight">
+      <Box {...args} mt="md" textType="note" textSize="md" textLeading="tight">
         <p>Note Medium Tight</p>
       </Box>
 
-      <Box {...defaultArgs} mt="xl" textType="note" textSize="lg" textLeading="default">
+      <Box {...args} mt="xl" textType="note" textSize="lg" textLeading="default">
         <p>Note Large Default</p>
       </Box>
-      <Box {...defaultArgs} mt="md" textType="note" textSize="lg" textLeading="narrow">
+      <Box {...args} mt="md" textType="note" textSize="lg" textLeading="narrow">
         <p>Note Large Narrow</p>
       </Box>
-      <Box {...defaultArgs} mt="md" textType="note" textSize="lg" textLeading="tight">
+      <Box {...args} mt="md" textType="note" textSize="lg" textLeading="tight">
         <p>Note Large Tight</p>
       </Box>
     </div>
   ),
+  args: defaultArgs,
 };

--- a/src/stories/Center.stories.tsx
+++ b/src/stories/Center.stories.tsx
@@ -78,7 +78,12 @@ export const MarginAndPadding: Story = {
 
 export const AsBox: Story = {
   render: () => (
-    <Center maxWidth='320px' pr="sm" pl="sm" as={<Box radius="md" backgroundColor='primary' pt="lg" pr="lg" pb="lg" pl="lg" />}>
+    <Center
+      maxWidth="320px"
+      pr="sm"
+      pl="sm"
+      as={<Box radius="md" backgroundColor="primary" pt="lg" pr="lg" pb="lg" pl="lg" />}
+    >
       <div>Center</div>
     </Center>
   ),

--- a/src/stories/Center.stories.tsx
+++ b/src/stories/Center.stories.tsx
@@ -75,3 +75,11 @@ export const MarginAndPadding: Story = {
     </div>
   ),
 };
+
+export const AsBox: Story = {
+  render: () => (
+    <Center maxWidth='320px' pr="sm" pl="sm" as={<Box radius="md" backgroundColor='primary' pt="lg" pr="lg" pb="lg" pl="lg" />}>
+      <div>Center</div>
+    </Center>
+  ),
+};

--- a/src/stories/Flex.stories.tsx
+++ b/src/stories/Flex.stories.tsx
@@ -184,7 +184,7 @@ export const MarginAndPadding: Story = {
 
 export const AsBox: Story = {
   render: () => (
-    <Flex spacing='md' as={<Box radius="md" backgroundColor='primary' pt="lg" pr="lg" pb="lg" pl="lg" />}>
+    <Flex spacing="md" as={<Box radius="md" backgroundColor="primary" pt="lg" pr="lg" pb="lg" pl="lg" />}>
       <div>item</div>
       <div>item</div>
       <div>item</div>

--- a/src/stories/Flex.stories.tsx
+++ b/src/stories/Flex.stories.tsx
@@ -1,5 +1,5 @@
 import { Meta, StoryObj } from '@storybook/react';
-import { Flex } from '..';
+import { Flex, Box } from '..';
 
 export default {
   component: Flex,
@@ -178,6 +178,16 @@ export const MarginAndPadding: Story = {
       <p>Section</p>
       <p>Section</p>
       <p>Section</p>
+    </Flex>
+  ),
+};
+
+export const AsBox: Story = {
+  render: () => (
+    <Flex spacing='md' as={<Box radius="md" backgroundColor='primary' pt="lg" pr="lg" pb="lg" pl="lg" />}>
+      <div>item</div>
+      <div>item</div>
+      <div>item</div>
     </Flex>
   ),
 };

--- a/src/stories/Stack.stories.tsx
+++ b/src/stories/Stack.stories.tsx
@@ -1,5 +1,5 @@
 import { Meta, StoryObj } from '@storybook/react';
-import { Stack } from '..';
+import { Stack, Box } from '..';
 import { Spacing } from '../types/style';
 
 export default {
@@ -99,6 +99,18 @@ export const BlockLevelElementsToFullWidth: Story = {
 export const MarginAndPadding: Story = {
   render: (args) => (
     <Stack {...args} mt="lg" mr="lg" mb="lg" ml="lg" pt="xxl" pr="xxl" pb="xxl" pl="xxl">
+      <p style={{ margin: 0 }}>Text</p>
+      <p style={{ margin: 0 }}>Text</p>
+      <p style={{ margin: 0 }}>Text</p>
+      <p style={{ margin: 0 }}>Text</p>
+    </Stack>
+  ),
+  args: defaultArgs,
+};
+
+export const AsBox: Story = {
+  render: (args) => (
+    <Stack {...args} as={<Box radius="md" backgroundColor='primary' pt="lg" pr="lg" pb="lg" pl="lg" />}>
       <p style={{ margin: 0 }}>Text</p>
       <p style={{ margin: 0 }}>Text</p>
       <p style={{ margin: 0 }}>Text</p>

--- a/src/stories/Stack.stories.tsx
+++ b/src/stories/Stack.stories.tsx
@@ -110,7 +110,7 @@ export const MarginAndPadding: Story = {
 
 export const AsBox: Story = {
   render: (args) => (
-    <Stack {...args} as={<Box radius="md" backgroundColor='primary' pt="lg" pr="lg" pb="lg" pl="lg" />}>
+    <Stack {...args} as={<Box radius="md" backgroundColor="primary" pt="lg" pr="lg" pb="lg" pl="lg" />}>
       <p style={{ margin: 0 }}>Text</p>
       <p style={{ margin: 0 }}>Text</p>
       <p style={{ margin: 0 }}>Text</p>


### PR DESCRIPTION
# Motivation

- There are several cases where a combination of Box and Stack is desired
- Nesting of components is difficult to see

# Overview

- To be able to pass `<Box>` to a layout component with `as` prop.
- Blocked on https://github.com/ubie-oss/ubie-ui/pull/80 

# Screenshot

## Center

**Rendered in the order `<Center>` > `<Box>`**

![スクリーンショット 2024-05-10 16 38 06 1](https://github.com/ubie-oss/ubie-ui/assets/10903851/2ab763d0-0dd6-40ee-ae70-b3fabdd9ffa6)

## Stack

**`<Box>` > `<Stack>` is rendered in this order, opposite to `<Center>`**

![スクリーンショット 2024-05-10 16 37 17](https://github.com/ubie-oss/ubie-ui/assets/10903851/95b81286-dda0-4c89-a2c9-751972de570b)

## Flex

**`<Box>` > `<Flex>` is rendered in this order, opposite to `<Center>`**

![スクリーンショット 2024-05-10 16 37 40](https://github.com/ubie-oss/ubie-ui/assets/10903851/c9566709-4b2c-4368-bbb0-d46a7e99eb27)


