### PR TITLE
Avoiding the inclusion of breaking changes in headless ui

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -74,7 +74,7 @@
         "vitest": "^0.34.3"
       },
       "peerDependencies": {
-        "@headlessui/react": ">1.7.0",
+        "@headlessui/react": ">1.7.0 <2.0.0",
         "@ubie/design-tokens": "^0.0.10 || ^0.1.0",
         "clsx": ">1.2.0",
         "react": "^17 || ^18",

--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
     "vitest": "^0.34.3"
   },
   "peerDependencies": {
-    "@headlessui/react": ">1.7.0",
+    "@headlessui/react": ">1.7.0 <2.0.0",
     "@ubie/design-tokens": "^0.0.10 || ^0.1.0",
     "clsx": ">1.2.0",
     "react": "^17 || ^18",


### PR DESCRIPTION
# Overview

- Breaking change from ver 2 of @headless/react
- Previous peerDependency specification may introduce v2
- Limit to v1 to avoid problems