### PR TITLE
Add `<Color>`, `<Bold>`

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,17 @@
     ".": {
       "import": "./dist/index.mjs",
       "default": "./dist/index.js"
+    },
+    "./font": {
+      "import": "./dist/font.mjs",
+      "default": "./dist/font.js"
+    }
+  },
+  "typesVersions": {
+    "*": {
+      "font": [
+        "./dist/font.d.ts"
+      ]
     }
   },
   "sideEffects": false,

--- a/src/components/Bold/Bold.module.css
+++ b/src/components/Bold/Bold.module.css
@@ -1,0 +1,4 @@
+.bold {
+  font-style: normal;
+  font-weight: bold;
+}

--- a/src/components/Bold/Bold.stories.tsx
+++ b/src/components/Bold/Bold.stories.tsx
@@ -1,0 +1,36 @@
+import { StoryObj, Meta } from '@storybook/react';
+import { Bold } from './Bold';
+import { Stack } from '../Stack/Stack';
+import { Text } from '../Text/Text';
+
+export default {
+  title: 'Typography/font/Bold',
+  component: Bold,
+} satisfies Meta<typeof Bold>;
+
+type Story = StoryObj<typeof Bold>;
+
+export const AsVarations: Story = {
+  render: () => {
+    return (
+      <Stack spacing="md">
+        <Bold>default(span)</Bold>
+        <Bold as="span">span</Bold>
+        <Bold as="b">b</Bold>
+        <Bold as="strong">strong</Bold>
+        <Bold as="em">em</Bold>
+        <Bold as="i">i</Bold>
+      </Stack>
+    );
+  },
+};
+
+export const WithText: Story = {
+  render: () => {
+    return (
+      <Text type="body" size="lg" color="main">
+        一部だけ<Bold>太字</Bold>にしたい
+      </Text>
+    );
+  },
+};

--- a/src/components/Bold/Bold.tsx
+++ b/src/components/Bold/Bold.tsx
@@ -2,6 +2,10 @@ import { type FC, PropsWithChildren } from 'react';
 import styles from './Bold.module.css';
 
 type Props = {
+  /**
+   * レンダリングされる要素
+   * @default span
+   */
   as?: 'span' | 'b' | 'strong' | 'em' | 'i';
 };
 

--- a/src/components/Bold/Bold.tsx
+++ b/src/components/Bold/Bold.tsx
@@ -1,0 +1,12 @@
+import { type FC, PropsWithChildren } from 'react';
+import styles from './Bold.module.css';
+
+type Props = {
+  as?: 'span' | 'b' | 'strong' | 'em' | 'i';
+};
+
+export const Bold: FC<PropsWithChildren<Props>> = ({ as = 'span', children }) => {
+  const BoldComponent = as;
+
+  return <BoldComponent className={styles.bold}>{children}</BoldComponent>;
+};

--- a/src/components/Color/Color.module.css
+++ b/src/components/Color/Color.module.css
@@ -1,0 +1,3 @@
+.color {
+  color: var(--text-color);
+}

--- a/src/components/Color/Color.stories.tsx
+++ b/src/components/Color/Color.stories.tsx
@@ -1,0 +1,43 @@
+import { StoryObj, Meta } from '@storybook/react';
+import { Color } from './Color';
+import { Box } from '../Box/Box';
+import { Stack } from '../Stack/Stack';
+import { Text } from '../Text/Text';
+
+export default {
+  title: 'Typography/Font/Color',
+  component: Color,
+} satisfies Meta<typeof Color>;
+
+type Story = StoryObj<typeof Color>;
+
+export const Colors: Story = {
+  render: () => {
+    return (
+      <Stack spacing="md">
+        <Color>default(main)</Color>
+        <Color color="main">main</Color>
+        <Color color="sub">sub</Color>
+        <Color color="primary">primary</Color>
+        <Color color="accent">accent</Color>
+        <Color color="alert">alert</Color>
+        <Color color="disabled">disabled</Color>
+        <Color color="link">link</Color>
+        <Color color="linkSub">linkSub</Color>
+        <Box pt="sm" pr="sm" pb="sm" pl="sm" backgroundColor="primaryDarken">
+          <Color color="white">white</Color>
+        </Box>
+      </Stack>
+    );
+  },
+};
+
+export const WithText: Story = {
+  render: () => {
+    return (
+      <Text type="body" size="lg" color="main">
+        一部だけ<Color color="accent">色</Color>を変えたい
+      </Text>
+    );
+  },
+};

--- a/src/components/Color/Color.tsx
+++ b/src/components/Color/Color.tsx
@@ -1,0 +1,18 @@
+import { type FC, PropsWithChildren } from 'react';
+import styles from './Color.module.css';
+import { TextColor } from '../../types/style';
+import { colorVariable } from '../../utils/style';
+
+type Props = {
+  /**
+   * 文字色
+   * @default main
+   */
+  color?: TextColor;
+};
+
+export const Color: FC<PropsWithChildren<Props>> = ({ color = 'main', children }) => (
+  <span className={styles.color} style={{ ...colorVariable(color) }}>
+    {children}
+  </span>
+);

--- a/src/components/Text/Text.tsx
+++ b/src/components/Text/Text.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { clsx } from 'clsx';
-import { FC, ReactNode } from 'react';
+import { FC, PropsWithChildren } from 'react';
 import styles from './Text.module.css';
 import { CustomDataAttributeProps } from '../../types/attributes';
 import {
@@ -35,10 +35,6 @@ type BaseProps = {
    * @default main
    */
   color?: TextColor;
-  /**
-   * 子要素
-   */
-  children: ReactNode;
   /**
    * HTMLのid属性
    */
@@ -135,7 +131,7 @@ type TextProps = BodyProps | HeadingProps | NoteProps | ButtonProps | TagProps;
 /**
  * Design Systemに則ったTypographyのスタイルを提供
  */
-export const Text: FC<TextProps> = ({
+export const Text: FC<PropsWithChildren<TextProps>> = ({
   as: TextComponent = 'p',
   size = 'md',
   type = 'body',

--- a/src/font.ts
+++ b/src/font.ts
@@ -1,0 +1,2 @@
+export { Bold } from './components/Bold/Bold';
+export { Color } from './components/Color/Color';

--- a/src/stories/Heading.stories.tsx
+++ b/src/stories/Heading.stories.tsx
@@ -3,6 +3,7 @@ import { UbieIcon, ThumbUpOutlineIcon, SetupIcon } from '@ubie/ubie-icons';
 import { Heading, Stack } from '../';
 
 export default {
+  title: 'Typography/Heading',
   component: Heading,
 } as Meta<typeof Heading>;
 

--- a/src/stories/Text.stories.tsx
+++ b/src/stories/Text.stories.tsx
@@ -2,6 +2,7 @@ import { Meta, StoryObj } from '@storybook/react';
 import { Text, Flex, Stack } from '../';
 
 export default {
+  title: 'Typography/Text',
   component: Text,
 } satisfies Meta<typeof Text>;
 


### PR DESCRIPTION
# Overview

- `<Text>` The case where you wanted to bold a part of the inside of a text was a pain in the ass.
- Nesting `<Text>`s meant that most of the props had to be re-specified
- Avoid re-specifying props by creating a component that only allows you to specify part of the font