### PR TITLE
Fix initial focus in Modals

### DIFF
--- a/src/components/ActionHalfModal/ActionHalfModal.module.css
+++ b/src/components/ActionHalfModal/ActionHalfModal.module.css
@@ -20,9 +20,6 @@
 
 .contents {
   padding: 0 var(--size-spacing-md);
-
-  /* May receive focus in the initial display. */
-  outline: none;
 }
 
 .modalBody {

--- a/src/components/ActionHalfModal/ActionHalfModal.spec.tsx
+++ b/src/components/ActionHalfModal/ActionHalfModal.spec.tsx
@@ -32,6 +32,16 @@ describe('ActionHalfModal', () => {
     expect(dialogHeadingElement).toHaveAttribute('id', 'header-id');
   });
 
+  test('If no header prop is present, text is inserted that serves as the default heading', async () => {
+    render(<CustomHeaderStory />);
+
+    await user.click(await screen.findByRole('button'));
+
+    const dialogHeadingElement = await screen.findByText('ダイアログ');
+
+    expect(document.activeElement).toEqual(dialogHeadingElement);
+  });
+
   test('header prop can be used to automatically link to a dialog', async () => {
     render(<DefaultStory />);
 

--- a/src/components/ActionHalfModal/ActionHalfModal.stories.tsx
+++ b/src/components/ActionHalfModal/ActionHalfModal.stories.tsx
@@ -10,24 +10,26 @@ export default {
 type Story = StoryObj<typeof ActionHalfModal>;
 
 const LongBody = () => (
-    <>
-        <p>Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the
-            industry&apos;s standard dummy text ever since the 1500s, when an unknown printer took a galley of
-            type and scrambled it to make a type specimen book. It has survived not only five centuries, but also
-            the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s
-            with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop
-            publishing software like Aldus PageMaker including versions of Lorem Ipsum.</p>
-        <p>Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical
-            Latin literature from 45 BC, making it over 2000 years old. Richard McClintock, a Latin professor at
-            Hampden-Sydney College in Virginia, looked up one of the more obscure Latin words, consectetur, from a
-            Lorem Ipsum passage, and going through the cites of the word in classical literature, discovered the
-            undoubtable source. Lorem Ipsum comes from sections 1.10.32 and 1.10.33 of &quot;de Finibus Bonorum et
-            Malorum&quot; (The Extremes of Good and Evil) by Cicero, written in 45 BC. This book is a treatise on the
-            theory of ethics, very popular during the Renaissance. The first line of Lorem Ipsum, &quot;Lorem
-            ipsum dolor sit amet..&quot;, comes from a line in section 1.10.32.</p>
-    </>
-)
-
+  <>
+    <p>
+      Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the
+      industry&apos;s standard dummy text ever since the 1500s, when an unknown printer took a galley of type and
+      scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into
+      electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of
+      Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus
+      PageMaker including versions of Lorem Ipsum.
+    </p>
+    <p>
+      Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin
+      literature from 45 BC, making it over 2000 years old. Richard McClintock, a Latin professor at Hampden-Sydney
+      College in Virginia, looked up one of the more obscure Latin words, consectetur, from a Lorem Ipsum passage, and
+      going through the cites of the word in classical literature, discovered the undoubtable source. Lorem Ipsum comes
+      from sections 1.10.32 and 1.10.33 of &quot;de Finibus Bonorum et Malorum&quot; (The Extremes of Good and Evil) by
+      Cicero, written in 45 BC. This book is a treatise on the theory of ethics, very popular during the Renaissance.
+      The first line of Lorem Ipsum, &quot;Lorem ipsum dolor sit amet..&quot;, comes from a line in section 1.10.32.
+    </p>
+  </>
+);
 
 const defaultArgs = {
   header: 'モーダル',
@@ -35,81 +37,81 @@ const defaultArgs = {
 };
 
 export const Default: Story = {
-    render: (args) => {
-        const [open, setOpen] = useState(true);
+  render: (args) => {
+    const [open, setOpen] = useState(true);
 
-        const onClose = useCallback(() => {
-            setOpen(false);
-        }, []);
+    const onClose = useCallback(() => {
+      setOpen(false);
+    }, []);
 
-        return (
-            <>
-                <button type="button" onClick={() => setOpen(true)}>
-                    Open Modal
-                </button>
-                <ActionHalfModal
-                    primaryActionLabel="アクション"
-                    onPrimaryAction={onClose}
-                    {...args}
-                    open={open}
-                    onClose={onClose}
-                />
-            </>
-        );
-    },
-    args: defaultArgs,
+    return (
+      <>
+        <button type="button" onClick={() => setOpen(true)}>
+          Open Modal
+        </button>
+        <ActionHalfModal
+          primaryActionLabel="アクション"
+          onPrimaryAction={onClose}
+          {...args}
+          open={open}
+          onClose={onClose}
+        />
+      </>
+    );
+  },
+  args: defaultArgs,
 };
 
 export const Secondary: Story = {
-    render: (args) => {
-        const [open, setOpen] = useState(false);
+  render: (args) => {
+    const [open, setOpen] = useState(false);
 
-        const onClose = useCallback(() => {
-            setOpen(false);
-        }, []);
+    const onClose = useCallback(() => {
+      setOpen(false);
+    }, []);
 
-        return (
-            <>
-                <button type="button" onClick={() => setOpen(true)}>
-                    Open Modal
-                </button>
-                <ActionHalfModal
-                    primaryActionLabel="アクション1"
-                    onPrimaryAction={onClose}
-                    secondaryActionLabel="アクション2"
-                    onSecondaryAction={onClose}
-                    {...args}
-                    open={open}
-                    onClose={onClose}
-                />
-            </>
-        );
-    },
-    args: defaultArgs,
+    return (
+      <>
+        <button type="button" onClick={() => setOpen(true)}>
+          Open Modal
+        </button>
+        <ActionHalfModal
+          primaryActionLabel="アクション1"
+          onPrimaryAction={onClose}
+          secondaryActionLabel="アクション2"
+          onSecondaryAction={onClose}
+          {...args}
+          open={open}
+          onClose={onClose}
+        />
+      </>
+    );
+  },
+  args: defaultArgs,
 };
 
 export const Fullscreen: Story = {
-    render: (args) => {
-        const [open, setOpen] = useState(false);
+  render: (args) => {
+    const [open, setOpen] = useState(false);
 
-        const onClose = useCallback(() => {
-            setOpen(false);
-        }, []);
+    const onClose = useCallback(() => {
+      setOpen(false);
+    }, []);
 
-        return (
-            <>
-                <button type="button" onClick={() => setOpen(true)}>
-                    Open Modal
-                </button>
-                <ActionHalfModal {...args} open={open} onClose={onClose} fullscreen/>
-            </>
-        );
-    },
-    args: defaultArgs,
+    return (
+      <>
+        <button type="button" onClick={() => setOpen(true)}>
+          Open Modal
+        </button>
+        <ActionHalfModal {...args} open={open} onClose={onClose} fullscreen />
+      </>
+    );
+  },
+  args: defaultArgs,
 };
 
 export const NoCloseButton: Story = {
-    render: (args) => {
+  render: (args) => {
     const [open, setOpen] = useState(false);
 
     const onClose = useCallback(() => {
@@ -219,7 +221,7 @@ export const CustomHeader: Story = {
           onClose={onClose}
         >
           <h2 id={headerId}>Header</h2>
-        <LongBody />
+          <LongBody />
         </ActionHalfModal>
       </>
     );

--- a/src/components/ActionHalfModal/ActionHalfModal.tsx
+++ b/src/components/ActionHalfModal/ActionHalfModal.tsx
@@ -4,7 +4,7 @@ import { Dialog, Transition } from '@headlessui/react';
 import { clsx } from 'clsx';
 import { FC, Fragment, PropsWithChildren, useCallback, useRef } from 'react';
 import styles from './ActionHalfModal.module.css';
-import { VisuallyHidden } from "../../sharedComponents/VisuallyHidden/VisuallyHidden";
+import { VisuallyHidden } from '../../sharedComponents/VisuallyHidden/VisuallyHidden';
 import { CustomDataAttributeProps } from '../../types/attributes';
 import { opacityToClassName } from '../../utils/style';
 import { AllOrNone } from '../../utils/types';
@@ -170,10 +170,12 @@ export const ActionHalfModal: FC<PropsWithChildren<Props>> = ({
               <Dialog.Title tabIndex={-1} ref={initialFocusRef} className={styles.header}>
                 {header}
               </Dialog.Title>
-            ) : <VisuallyHidden tabIndex={-1} ref={initialFocusRef}>ダイアログ</VisuallyHidden>}
-            <div className={styles.contents}>
-              {children}
-            </div>
+            ) : (
+              <VisuallyHidden tabIndex={-1} ref={initialFocusRef}>
+                ダイアログ
+              </VisuallyHidden>
+            )}
+            <div className={styles.contents}>{children}</div>
             <div className={styles.buttonContainer}>
               {onPrimaryAction && primaryActionLabel && (
                 <Button block onClick={onPrimaryAction} aria-label={primaryActionLabel} variant={primaryActionColor}>

--- a/src/components/ActionHalfModal/ActionHalfModal.tsx
+++ b/src/components/ActionHalfModal/ActionHalfModal.tsx
@@ -2,7 +2,7 @@
 
 import { Dialog, Transition } from '@headlessui/react';
 import { clsx } from 'clsx';
-import {FC, Fragment, PropsWithChildren, useCallback, useRef} from 'react';
+import { FC, Fragment, PropsWithChildren, useCallback, useRef } from 'react';
 import styles from './ActionHalfModal.module.css';
 import { CustomDataAttributeProps } from '../../types/attributes';
 import { opacityToClassName } from '../../utils/style';
@@ -114,7 +114,7 @@ export const ActionHalfModal: FC<PropsWithChildren<Props>> = ({
 }) => {
   const opacityClassName = opacityToClassName(overlayOpacity);
 
-  const initialFocusRef = useRef(null)
+  const initialFocusRef = useRef(null);
 
   const dialogRef = useCallback(
     (node: HTMLDivElement | null) => {
@@ -165,8 +165,14 @@ export const ActionHalfModal: FC<PropsWithChildren<Props>> = ({
               bodyScroll && styles.bodyScroll,
             )}
           >
-            {header && <Dialog.Title tabIndex={-1} ref={initialFocusRef} className={styles.header}>{header}</Dialog.Title>}
-            <div tabIndex={-1} ref={header == null ? initialFocusRef : null} className={styles.contents}>{children}</div>
+            {header && (
+              <Dialog.Title tabIndex={-1} ref={initialFocusRef} className={styles.header}>
+                {header}
+              </Dialog.Title>
+            )}
+            <div tabIndex={-1} ref={header == null ? initialFocusRef : null} className={styles.contents}>
+              {children}
+            </div>
             <div className={styles.buttonContainer}>
               {onPrimaryAction && primaryActionLabel && (
                 <Button block onClick={onPrimaryAction} aria-label={primaryActionLabel} variant={primaryActionColor}>

--- a/src/components/ActionHalfModal/ActionHalfModal.tsx
+++ b/src/components/ActionHalfModal/ActionHalfModal.tsx
@@ -4,6 +4,7 @@ import { Dialog, Transition } from '@headlessui/react';
 import { clsx } from 'clsx';
 import { FC, Fragment, PropsWithChildren, useCallback, useRef } from 'react';
 import styles from './ActionHalfModal.module.css';
+import { VisuallyHidden } from "../../sharedComponents/VisuallyHidden/VisuallyHidden";
 import { CustomDataAttributeProps } from '../../types/attributes';
 import { opacityToClassName } from '../../utils/style';
 import { AllOrNone } from '../../utils/types';
@@ -165,12 +166,12 @@ export const ActionHalfModal: FC<PropsWithChildren<Props>> = ({
               bodyScroll && styles.bodyScroll,
             )}
           >
-            {header && (
+            {header != null ? (
               <Dialog.Title tabIndex={-1} ref={initialFocusRef} className={styles.header}>
                 {header}
               </Dialog.Title>
-            )}
-            <div tabIndex={-1} ref={header == null ? initialFocusRef : null} className={styles.contents}>
+            ) : <VisuallyHidden tabIndex={-1} ref={initialFocusRef}>ダイアログ</VisuallyHidden>}
+            <div className={styles.contents}>
               {children}
             </div>
             <div className={styles.buttonContainer}>

--- a/src/components/ActionModal/ActionModal.module.css
+++ b/src/components/ActionModal/ActionModal.module.css
@@ -45,11 +45,6 @@
   height: calc(100% - 48px);
 }
 
-.contents {
-  /* May receive focus in the initial display. */
-  outline: none;
-}
-
 .modalBody.fixedHeight .contents {
   height: 100%;
   min-height: 400px;

--- a/src/components/ActionModal/ActionModal.spec.tsx
+++ b/src/components/ActionModal/ActionModal.spec.tsx
@@ -32,6 +32,17 @@ describe('ActionModal', () => {
     expect(dialogHeadingElement).toHaveAttribute('id', 'header-id');
   });
 
+  test('If no header prop is present, text is inserted that serves as the default heading', async () => {
+    render(<CustomHeaderStory />);
+
+    await user.click(await screen.findByRole('button'));
+
+    const dialogHeadingElement = await screen.findByText('ダイアログ');
+
+    expect(document.activeElement).toEqual(dialogHeadingElement);
+  });
+
+
   test('header prop can be used to automatically link to a dialog', async () => {
     render(<DefaultStory />);
 

--- a/src/components/ActionModal/ActionModal.spec.tsx
+++ b/src/components/ActionModal/ActionModal.spec.tsx
@@ -42,7 +42,6 @@ describe('ActionModal', () => {
     expect(document.activeElement).toEqual(dialogHeadingElement);
   });
 
-
   test('header prop can be used to automatically link to a dialog', async () => {
     render(<DefaultStory />);
 

--- a/src/components/ActionModal/ActionModal.stories.tsx
+++ b/src/components/ActionModal/ActionModal.stories.tsx
@@ -18,22 +18,25 @@ const defaultArgs: Partial<ComponentProps<typeof ActionModal>> = {
 };
 
 const LongBody = () => (
-    <>
-        <p>Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the
-            industry&apos;s standard dummy text ever since the 1500s, when an unknown printer took a galley of
-            type and scrambled it to make a type specimen book. It has survived not only five centuries, but also
-            the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s
-            with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop
-            publishing software like Aldus PageMaker including versions of Lorem Ipsum.</p>
-        <p>Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical
-            Latin literature from 45 BC, making it over 2000 years old. Richard McClintock, a Latin professor at
-            Hampden-Sydney College in Virginia, looked up one of the more obscure Latin words, consectetur, from a
-            Lorem Ipsum passage, and going through the cites of the word in classical literature, discovered the
-            undoubtable source. Lorem Ipsum comes from sections 1.10.32 and 1.10.33 of &quot;de Finibus Bonorum et
-            Malorum&quot; (The Extremes of Good and Evil) by Cicero, written in 45 BC. This book is a treatise on the
-            theory of ethics, very popular during the Renaissance. The first line of Lorem Ipsum, &quot;Lorem
-            ipsum dolor sit amet..&quot;, comes from a line in section 1.10.32.</p>
-    </>
+  <>
+    <p>
+      Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the
+      industry&apos;s standard dummy text ever since the 1500s, when an unknown printer took a galley of type and
+      scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into
+      electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of
+      Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus
+      PageMaker including versions of Lorem Ipsum.
+    </p>
+    <p>
+      Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin
+      literature from 45 BC, making it over 2000 years old. Richard McClintock, a Latin professor at Hampden-Sydney
+      College in Virginia, looked up one of the more obscure Latin words, consectetur, from a Lorem Ipsum passage, and
+      going through the cites of the word in classical literature, discovered the undoubtable source. Lorem Ipsum comes
+      from sections 1.10.32 and 1.10.33 of &quot;de Finibus Bonorum et Malorum&quot; (The Extremes of Good and Evil) by
+      Cicero, written in 45 BC. This book is a treatise on the theory of ethics, very popular during the Renaissance.
+      The first line of Lorem Ipsum, &quot;Lorem ipsum dolor sit amet..&quot;, comes from a line in section 1.10.32.
+    </p>
+  </>
 );
 
 export const Default: Story = {
@@ -45,72 +48,71 @@ export const Default: Story = {
         <button type="button" onClick={() => setOpen(true)}>
           Open Modal
         </button>
-          <ActionModal {...args} open={open} onPrimaryAction={() => setOpen(false)} onClose={() => setOpen(false)}>
-              <LongBody />
-          </ActionModal>
+        <ActionModal {...args} open={open} onPrimaryAction={() => setOpen(false)} onClose={() => setOpen(false)}>
+          <LongBody />
+        </ActionModal>
       </>
     );
   },
-    args: defaultArgs,
+  args: defaultArgs,
 };
 
 export const Secondary: Story = {
-    render: (args) => {
-        const [open, setOpen] = useState(true);
+  render: (args) => {
+    const [open, setOpen] = useState(true);
 
-        return (
-            <>
-                <button type="button" onClick={() => setOpen(true)}>
-                    Open Modal
-                </button>
-                <ActionModal
-                    {...args}
-                    open={open}
-                    onPrimaryAction={() => setOpen(false)}
-                    secondaryActionLabel={'このまま回答を続ける'}
-                    onSecondaryAction={() => setOpen(false)}
-                    onClose={() => setOpen(false)}
-                >
-                    Default
-                </ActionModal>
-            </>
-        );
-    },
-    args: defaultArgs,
+    return (
+      <>
+        <button type="button" onClick={() => setOpen(true)}>
+          Open Modal
+        </button>
+        <ActionModal
+          {...args}
+          open={open}
+          onPrimaryAction={() => setOpen(false)}
+          secondaryActionLabel={'このまま回答を続ける'}
+          onSecondaryAction={() => setOpen(false)}
+          onClose={() => setOpen(false)}
+        >
+          Default
+        </ActionModal>
+      </>
+    );
+  },
+  args: defaultArgs,
 };
 
 export const FixedHeight: Story = {
-    render: (args) => {
-        const [open, setOpen] = useState(false);
+  render: (args) => {
+    const [open, setOpen] = useState(false);
 
-        return (
-            <>
-                <button type="button" onClick={() => setOpen(true)}>
-                    Open Modal
-                </button>
-                <ActionModal {...args} open={open} onPrimaryAction={() => setOpen(false)}
-                             onClose={() => setOpen(false)}>
-                    <p>Content</p>
-                </ActionModal>
-            </>
-        );
-    },
-    args: {
-        ...defaultArgs,
-        fixedHeight: true,
-    },
+    return (
+      <>
+        <button type="button" onClick={() => setOpen(true)}>
+          Open Modal
+        </button>
+        <ActionModal {...args} open={open} onPrimaryAction={() => setOpen(false)} onClose={() => setOpen(false)}>
+          <p>Content</p>
+        </ActionModal>
+      </>
+    );
+  },
+  args: {
+    ...defaultArgs,
+    fixedHeight: true,
+  },
 };
 
 export const Customized: Story = {
-    render: (args) => {
-        const [open, setOpen] = useState(false);
+  render: (args) => {
+    const [open, setOpen] = useState(false);
 
-        return (
-            <>
-                <button type="button" onClick={() => setOpen(true)}>
-                    Open Modal
-                </button>
-                <ActionModal {...args} open={open} onPrimaryAction={() => setOpen(false)} onClose={() => setOpen(false)}>
+    return (
+      <>
+        <button type="button" onClick={() => setOpen(true)}>
+          Open Modal
+        </button>
+        <ActionModal {...args} open={open} onPrimaryAction={() => setOpen(false)} onClose={() => setOpen(false)}>
           <p>Customized</p>
         </ActionModal>
       </>
@@ -185,7 +187,7 @@ export const CustomHeader: Story = {
           ariaLabelledby={headerId}
         >
           <h2 id={headerId}>Custom Heading</h2>
-            <LongBody />
+          <LongBody />
         </ActionModal>
       </>
     );
@@ -195,4 +197,3 @@ export const CustomHeader: Story = {
     header: undefined,
   },
 };
-

--- a/src/components/ActionModal/ActionModal.tsx
+++ b/src/components/ActionModal/ActionModal.tsx
@@ -2,7 +2,7 @@
 
 import { Dialog, Transition } from '@headlessui/react';
 import clsx from 'clsx';
-import {FC, Fragment, PropsWithChildren, useCallback, useRef} from 'react';
+import { FC, Fragment, PropsWithChildren, useCallback, useRef } from 'react';
 import styles from './ActionModal.module.css';
 import { Button } from '../../';
 import { CustomDataAttributeProps } from '../../types/attributes';
@@ -140,8 +140,14 @@ export const ActionModal: FC<Props> = ({
       >
         <Dialog.Overlay className={clsx(styles.overlay, styles[opacityClassName])} />
         <div className={clsx(styles.modalBody, !header && styles.headerLess, fixedHeight && styles.fixedHeight)}>
-          {header && <Dialog.Title tabIndex={-1} ref={initialFocusRef} className={styles.header}>{header}</Dialog.Title>}
-          <div tabIndex={-1} ref={header == null ? initialFocusRef : null} className={styles.contents}>{children}</div>
+          {header && (
+            <Dialog.Title tabIndex={-1} ref={initialFocusRef} className={styles.header}>
+              {header}
+            </Dialog.Title>
+          )}
+          <div tabIndex={-1} ref={header == null ? initialFocusRef : null} className={styles.contents}>
+            {children}
+          </div>
           <div className={styles.buttonContainer}>
             {onPrimaryAction && primaryActionLabel && (
               <Button block onClick={onPrimaryAction} variant={primaryActionColor}>

--- a/src/components/ActionModal/ActionModal.tsx
+++ b/src/components/ActionModal/ActionModal.tsx
@@ -5,6 +5,7 @@ import clsx from 'clsx';
 import { FC, Fragment, PropsWithChildren, useCallback, useRef } from 'react';
 import styles from './ActionModal.module.css';
 import { Button } from '../../';
+import { VisuallyHidden } from "../../sharedComponents/VisuallyHidden/VisuallyHidden";
 import { CustomDataAttributeProps } from '../../types/attributes';
 import { opacityToClassName } from '../../utils/style';
 import { AllOrNone } from '../../utils/types';
@@ -140,12 +141,12 @@ export const ActionModal: FC<Props> = ({
       >
         <Dialog.Overlay className={clsx(styles.overlay, styles[opacityClassName])} />
         <div className={clsx(styles.modalBody, !header && styles.headerLess, fixedHeight && styles.fixedHeight)}>
-          {header && (
+          {header != null ? (
             <Dialog.Title tabIndex={-1} ref={initialFocusRef} className={styles.header}>
               {header}
             </Dialog.Title>
-          )}
-          <div tabIndex={-1} ref={header == null ? initialFocusRef : null} className={styles.contents}>
+          ) : <VisuallyHidden tabIndex={-1} ref={initialFocusRef}>ダイアログ</VisuallyHidden>}
+          <div className={styles.contents}>
             {children}
           </div>
           <div className={styles.buttonContainer}>

--- a/src/components/ActionModal/ActionModal.tsx
+++ b/src/components/ActionModal/ActionModal.tsx
@@ -5,7 +5,7 @@ import clsx from 'clsx';
 import { FC, Fragment, PropsWithChildren, useCallback, useRef } from 'react';
 import styles from './ActionModal.module.css';
 import { Button } from '../../';
-import { VisuallyHidden } from "../../sharedComponents/VisuallyHidden/VisuallyHidden";
+import { VisuallyHidden } from '../../sharedComponents/VisuallyHidden/VisuallyHidden';
 import { CustomDataAttributeProps } from '../../types/attributes';
 import { opacityToClassName } from '../../utils/style';
 import { AllOrNone } from '../../utils/types';
@@ -145,10 +145,12 @@ export const ActionModal: FC<Props> = ({
             <Dialog.Title tabIndex={-1} ref={initialFocusRef} className={styles.header}>
               {header}
             </Dialog.Title>
-          ) : <VisuallyHidden tabIndex={-1} ref={initialFocusRef}>ダイアログ</VisuallyHidden>}
-          <div className={styles.contents}>
-            {children}
-          </div>
+          ) : (
+            <VisuallyHidden tabIndex={-1} ref={initialFocusRef}>
+              ダイアログ
+            </VisuallyHidden>
+          )}
+          <div className={styles.contents}>{children}</div>
           <div className={styles.buttonContainer}>
             {onPrimaryAction && primaryActionLabel && (
               <Button block onClick={onPrimaryAction} variant={primaryActionColor}>

--- a/src/components/MessageHalfModal/MessageHalfModal.module.css
+++ b/src/components/MessageHalfModal/MessageHalfModal.module.css
@@ -20,9 +20,6 @@
 
 .contents {
   padding: 0 var(--size-spacing-md);
-
-  /* May receive focus in the initial display. */
-  outline: none;
 }
 
 .modalBody {

--- a/src/components/MessageHalfModal/MessageHalfModal.spec.tsx
+++ b/src/components/MessageHalfModal/MessageHalfModal.spec.tsx
@@ -43,6 +43,16 @@ describe('MessageHalfModal', () => {
     expect(dialogHeadingElement).toHaveAttribute('id', 'header-id');
   });
 
+  test('If no header prop is present, text is inserted that serves as the default heading', async () => {
+    render(<CustomHeaderStory />);
+
+    await user.click(await screen.findByRole('button'));
+
+    const dialogHeadingElement = await screen.findByText('ダイアログ');
+
+    expect(document.activeElement).toEqual(dialogHeadingElement);
+  });
+
   test('header prop can be used to automatically link to a dialog', async () => {
     render(<DefaultStory />);
 

--- a/src/components/MessageHalfModal/MessageHalfModal.stories.tsx
+++ b/src/components/MessageHalfModal/MessageHalfModal.stories.tsx
@@ -10,27 +10,30 @@ export default {
 type Story = StoryObj<typeof MessageHalfModal>;
 
 const LongBody = () => (
-    <>
-        <p>Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the
-            industry&apos;s standard dummy text ever since the 1500s, when an unknown printer took a galley of
-            type and scrambled it to make a type specimen book. It has survived not only five centuries, but also
-            the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s
-            with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop
-            publishing software like Aldus PageMaker including versions of Lorem Ipsum.</p>
-        <p>Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical
-            Latin literature from 45 BC, making it over 2000 years old. Richard McClintock, a Latin professor at
-            Hampden-Sydney College in Virginia, looked up one of the more obscure Latin words, consectetur, from a
-            Lorem Ipsum passage, and going through the cites of the word in classical literature, discovered the
-            undoubtable source. Lorem Ipsum comes from sections 1.10.32 and 1.10.33 of &quot;de Finibus Bonorum et
-            Malorum&quot; (The Extremes of Good and Evil) by Cicero, written in 45 BC. This book is a treatise on the
-            theory of ethics, very popular during the Renaissance. The first line of Lorem Ipsum, &quot;Lorem
-            ipsum dolor sit amet..&quot;, comes from a line in section 1.10.32.</p>
-    </>
-)
+  <>
+    <p>
+      Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the
+      industry&apos;s standard dummy text ever since the 1500s, when an unknown printer took a galley of type and
+      scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into
+      electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of
+      Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus
+      PageMaker including versions of Lorem Ipsum.
+    </p>
+    <p>
+      Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin
+      literature from 45 BC, making it over 2000 years old. Richard McClintock, a Latin professor at Hampden-Sydney
+      College in Virginia, looked up one of the more obscure Latin words, consectetur, from a Lorem Ipsum passage, and
+      going through the cites of the word in classical literature, discovered the undoubtable source. Lorem Ipsum comes
+      from sections 1.10.32 and 1.10.33 of &quot;de Finibus Bonorum et Malorum&quot; (The Extremes of Good and Evil) by
+      Cicero, written in 45 BC. This book is a treatise on the theory of ethics, very popular during the Renaissance.
+      The first line of Lorem Ipsum, &quot;Lorem ipsum dolor sit amet..&quot;, comes from a line in section 1.10.32.
+    </p>
+  </>
+);
 
 const defaultArgs = {
-    header: 'モーダル',
-    children: <LongBody />,
+  header: 'モーダル',
+  children: <LongBody />,
 };
 
 export const Default: Story = {
@@ -42,12 +45,12 @@ export const Default: Story = {
     }, []);
 
     return (
-        <>
-          <button type="button" onClick={() => setOpen(true)}>
-            Open Modal
-          </button>
-          <MessageHalfModal {...args} open={open} onClose={onClose}/>
-        </>
+      <>
+        <button type="button" onClick={() => setOpen(true)}>
+          Open Modal
+        </button>
+        <MessageHalfModal {...args} open={open} onClose={onClose} />
+      </>
     );
   },
   args: defaultArgs,
@@ -62,12 +65,12 @@ export const Fullscreen: Story = {
     }, []);
 
     return (
-        <>
-          <button type="button" onClick={() => setOpen(true)}>
-            Open Modal
-          </button>
-          <MessageHalfModal {...args} open={open} onClose={onClose} fullscreen/>
-        </>
+      <>
+        <button type="button" onClick={() => setOpen(true)}>
+          Open Modal
+        </button>
+        <MessageHalfModal {...args} open={open} onClose={onClose} fullscreen />
+      </>
     );
   },
   args: defaultArgs,
@@ -82,12 +85,12 @@ export const NoCloseButton: Story = {
     }, []);
 
     return (
-        <>
-          <button type="button" onClick={() => setOpen(true)}>
-            Open Modal
-          </button>
-          <MessageHalfModal showClose={false} {...args} open={open} onClose={onClose}/>
-        </>
+      <>
+        <button type="button" onClick={() => setOpen(true)}>
+          Open Modal
+        </button>
+        <MessageHalfModal showClose={false} {...args} open={open} onClose={onClose} />
+      </>
     );
   },
   args: defaultArgs,
@@ -102,11 +105,11 @@ export const WithCustomDataAttribute: Story = {
     }, []);
 
     return (
-        <>
-          <button type="button" onClick={() => setOpen(true)}>
-            Open Modal
-          </button>
-          <MessageHalfModal {...args} open={open} onClose={onClose} />
+      <>
+        <button type="button" onClick={() => setOpen(true)}>
+          Open Modal
+        </button>
+        <MessageHalfModal {...args} open={open} onClose={onClose} />
       </>
     );
   },
@@ -156,7 +159,7 @@ export const CustomHeader: Story = {
         </button>
         <MessageHalfModal ariaLabelledby={headerId} {...args} open={open} onClose={onClose}>
           <h2 id={headerId}>Heading</h2>
-          <LongBody/>
+          <LongBody />
         </MessageHalfModal>
       </>
     );

--- a/src/components/MessageHalfModal/MessageHalfModal.tsx
+++ b/src/components/MessageHalfModal/MessageHalfModal.tsx
@@ -2,7 +2,7 @@
 
 import { Dialog, Transition } from '@headlessui/react';
 import { clsx } from 'clsx';
-import {FC, Fragment, PropsWithChildren, useCallback, useRef} from 'react';
+import { FC, Fragment, PropsWithChildren, useCallback, useRef } from 'react';
 import styles from './MessageHalfModal.module.css';
 import { CustomDataAttributeProps } from '../../types/attributes';
 import { opacityToClassName } from '../../utils/style';
@@ -134,8 +134,14 @@ export const MessageHalfModal: FC<PropsWithChildren<Props>> = ({
               bodyScroll && styles.bodyScroll,
             )}
           >
-            {header && <Dialog.Title tabIndex={-1} ref={initialFocusRef} className={styles.header}>{header}</Dialog.Title>}
-            <div tabIndex={-1} ref={header == null ? initialFocusRef : null} className={styles.contents}>{children}</div>
+            {header && (
+              <Dialog.Title tabIndex={-1} ref={initialFocusRef} className={styles.header}>
+                {header}
+              </Dialog.Title>
+            )}
+            <div tabIndex={-1} ref={header == null ? initialFocusRef : null} className={styles.contents}>
+              {children}
+            </div>
             <div className={styles.buttonContainer}>
               {showClose && (
                 <Button variant="primary" onClick={onClose} aria-label={closeLabel}>

--- a/src/components/MessageHalfModal/MessageHalfModal.tsx
+++ b/src/components/MessageHalfModal/MessageHalfModal.tsx
@@ -4,7 +4,7 @@ import { Dialog, Transition } from '@headlessui/react';
 import { clsx } from 'clsx';
 import { FC, Fragment, PropsWithChildren, useCallback, useRef } from 'react';
 import styles from './MessageHalfModal.module.css';
-import { VisuallyHidden } from "../../sharedComponents/VisuallyHidden/VisuallyHidden";
+import { VisuallyHidden } from '../../sharedComponents/VisuallyHidden/VisuallyHidden';
 import { CustomDataAttributeProps } from '../../types/attributes';
 import { opacityToClassName } from '../../utils/style';
 import { Button } from '../Button/Button';
@@ -139,10 +139,12 @@ export const MessageHalfModal: FC<PropsWithChildren<Props>> = ({
               <Dialog.Title tabIndex={-1} ref={initialFocusRef} className={styles.header}>
                 {header}
               </Dialog.Title>
-            ) : <VisuallyHidden tabIndex={-1} ref={initialFocusRef}>ダイアログ</VisuallyHidden>}
-            <div className={styles.contents}>
-              {children}
-            </div>
+            ) : (
+              <VisuallyHidden tabIndex={-1} ref={initialFocusRef}>
+                ダイアログ
+              </VisuallyHidden>
+            )}
+            <div className={styles.contents}>{children}</div>
             <div className={styles.buttonContainer}>
               {showClose && (
                 <Button variant="primary" onClick={onClose} aria-label={closeLabel}>

--- a/src/components/MessageHalfModal/MessageHalfModal.tsx
+++ b/src/components/MessageHalfModal/MessageHalfModal.tsx
@@ -4,6 +4,7 @@ import { Dialog, Transition } from '@headlessui/react';
 import { clsx } from 'clsx';
 import { FC, Fragment, PropsWithChildren, useCallback, useRef } from 'react';
 import styles from './MessageHalfModal.module.css';
+import { VisuallyHidden } from "../../sharedComponents/VisuallyHidden/VisuallyHidden";
 import { CustomDataAttributeProps } from '../../types/attributes';
 import { opacityToClassName } from '../../utils/style';
 import { Button } from '../Button/Button';
@@ -134,12 +135,12 @@ export const MessageHalfModal: FC<PropsWithChildren<Props>> = ({
               bodyScroll && styles.bodyScroll,
             )}
           >
-            {header && (
+            {header != null ? (
               <Dialog.Title tabIndex={-1} ref={initialFocusRef} className={styles.header}>
                 {header}
               </Dialog.Title>
-            )}
-            <div tabIndex={-1} ref={header == null ? initialFocusRef : null} className={styles.contents}>
+            ) : <VisuallyHidden tabIndex={-1} ref={initialFocusRef}>ダイアログ</VisuallyHidden>}
+            <div className={styles.contents}>
               {children}
             </div>
             <div className={styles.buttonContainer}>

--- a/src/components/MessageModal/MessageModal.module.css
+++ b/src/components/MessageModal/MessageModal.module.css
@@ -43,9 +43,6 @@
 
 .contents {
   text-align: center;
-
-  /* May receive focus in the initial display. */
-  outline: none;
 }
 
 .modalBody.fixedHeight .contents {

--- a/src/components/MessageModal/MessageModal.spec.tsx
+++ b/src/components/MessageModal/MessageModal.spec.tsx
@@ -32,6 +32,17 @@ describe('MessageModal', () => {
     expect(dialogHeadingElement).toHaveAttribute('id', 'header-id');
   });
 
+  test('If no header prop is present, text is inserted that serves as the default heading', async () => {
+    render(<CustomHeaderStory />);
+
+    await user.click(await screen.findByRole('button'));
+
+    const dialogHeadingElement = await screen.findByText('ダイアログ');
+
+    expect(document.activeElement).toEqual(dialogHeadingElement);
+  });
+
+
   test('header prop can be used to automatically link to a dialog', async () => {
     render(<DefaultStory />);
 

--- a/src/components/MessageModal/MessageModal.spec.tsx
+++ b/src/components/MessageModal/MessageModal.spec.tsx
@@ -42,7 +42,6 @@ describe('MessageModal', () => {
     expect(document.activeElement).toEqual(dialogHeadingElement);
   });
 
-
   test('header prop can be used to automatically link to a dialog', async () => {
     render(<DefaultStory />);
 

--- a/src/components/MessageModal/MessageModal.stories.tsx
+++ b/src/components/MessageModal/MessageModal.stories.tsx
@@ -14,23 +14,26 @@ const meta: Meta<typeof MessageModal> = {
 };
 
 const LongBody = () => (
-    <>
-        <p>Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the
-            industry&apos;s standard dummy text ever since the 1500s, when an unknown printer took a galley of
-            type and scrambled it to make a type specimen book. It has survived not only five centuries, but also
-            the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s
-            with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop
-            publishing software like Aldus PageMaker including versions of Lorem Ipsum.</p>
-        <p>Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical
-            Latin literature from 45 BC, making it over 2000 years old. Richard McClintock, a Latin professor at
-            Hampden-Sydney College in Virginia, looked up one of the more obscure Latin words, consectetur, from a
-            Lorem Ipsum passage, and going through the cites of the word in classical literature, discovered the
-            undoubtable source. Lorem Ipsum comes from sections 1.10.32 and 1.10.33 of &quot;de Finibus Bonorum et
-            Malorum&quot; (The Extremes of Good and Evil) by Cicero, written in 45 BC. This book is a treatise on the
-            theory of ethics, very popular during the Renaissance. The first line of Lorem Ipsum, &quot;Lorem
-            ipsum dolor sit amet..&quot;, comes from a line in section 1.10.32.</p>
-    </>
-)
+  <>
+    <p>
+      Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the
+      industry&apos;s standard dummy text ever since the 1500s, when an unknown printer took a galley of type and
+      scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into
+      electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of
+      Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus
+      PageMaker including versions of Lorem Ipsum.
+    </p>
+    <p>
+      Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin
+      literature from 45 BC, making it over 2000 years old. Richard McClintock, a Latin professor at Hampden-Sydney
+      College in Virginia, looked up one of the more obscure Latin words, consectetur, from a Lorem Ipsum passage, and
+      going through the cites of the word in classical literature, discovered the undoubtable source. Lorem Ipsum comes
+      from sections 1.10.32 and 1.10.33 of &quot;de Finibus Bonorum et Malorum&quot; (The Extremes of Good and Evil) by
+      Cicero, written in 45 BC. This book is a treatise on the theory of ethics, very popular during the Renaissance.
+      The first line of Lorem Ipsum, &quot;Lorem ipsum dolor sit amet..&quot;, comes from a line in section 1.10.32.
+    </p>
+  </>
+);
 
 export default meta;
 
@@ -41,7 +44,7 @@ const defaultArgs: Partial<ComponentProps<typeof MessageModal>> = {
   overlayOpacity: 'normal',
   isStatic: false,
   fixedHeight: false,
-  children: <LongBody />
+  children: <LongBody />,
 };
 
 export const Default: Story = {
@@ -49,12 +52,12 @@ export const Default: Story = {
     const [open, setOpen] = useState(true);
 
     return (
-        <>
-          <button type="button" onClick={() => setOpen(true)}>
-            Open Modal
-          </button>
-          <MessageModal {...args} open={open} onClose={() => setOpen(false)}/>
-        </>
+      <>
+        <button type="button" onClick={() => setOpen(true)}>
+          Open Modal
+        </button>
+        <MessageModal {...args} open={open} onClose={() => setOpen(false)} />
+      </>
     );
   },
   args: {
@@ -68,12 +71,12 @@ export const FixedHeight: Story = {
     const [open, setOpen] = useState(false);
 
     return (
-        <>
-          <button type="button" onClick={() => setOpen(true)}>
-            Open Modal
-          </button>
-          <MessageModal {...args} open={open} onClose={() => setOpen(false)}/>
-        </>
+      <>
+        <button type="button" onClick={() => setOpen(true)}>
+          Open Modal
+        </button>
+        <MessageModal {...args} open={open} onClose={() => setOpen(false)} />
+      </>
     );
   },
   args: defaultArgs,
@@ -84,12 +87,12 @@ export const OverlayDarker: Story = {
     const [open, setOpen] = useState(false);
 
     return (
-        <>
-          <button type="button" onClick={() => setOpen(true)}>
-            Open Modal
-          </button>
-          <MessageModal {...args} open={open} onClose={() => setOpen(false)} fixedHeight/>
-        </>
+      <>
+        <button type="button" onClick={() => setOpen(true)}>
+          Open Modal
+        </button>
+        <MessageModal {...args} open={open} onClose={() => setOpen(false)} fixedHeight />
+      </>
     );
   },
   args: {
@@ -103,12 +106,12 @@ export const CustomDataAttribute: Story = {
     const [open, setOpen] = useState(false);
 
     return (
-        <>
-          <button type="button" onClick={() => setOpen(true)}>
-            Open Modal
-          </button>
-          <MessageModal {...args} open={open} onClose={() => setOpen(false)}/>
-        </>
+      <>
+        <button type="button" onClick={() => setOpen(true)}>
+          Open Modal
+        </button>
+        <MessageModal {...args} open={open} onClose={() => setOpen(false)} />
+      </>
     );
   },
   args: {
@@ -149,7 +152,7 @@ export const CustomHeader: Story = {
         </button>
         <MessageModal ariaLabelledby={headerId} {...args} open={open} onClose={() => setOpen(false)}>
           <h2 id={headerId}>Heading</h2>
-            <LongBody />
+          <LongBody />
         </MessageModal>
       </>
     );

--- a/src/components/MessageModal/MessageModal.tsx
+++ b/src/components/MessageModal/MessageModal.tsx
@@ -5,6 +5,7 @@ import clsx from 'clsx';
 import { FC, Fragment, PropsWithChildren, useCallback, useRef } from 'react';
 import styles from './MessageModal.module.css';
 import { Button } from '../../';
+import { VisuallyHidden } from "../../sharedComponents/VisuallyHidden/VisuallyHidden";
 import { CustomDataAttributeProps } from '../../types/attributes';
 import { opacityToClassName } from '../../utils/style';
 
@@ -103,12 +104,12 @@ export const MessageModal: FC<Props> = ({
       >
         <Dialog.Overlay className={clsx(styles.overlay, styles[opacityClassName])} />
         <div className={clsx(styles.modalBody, fixedHeight && styles.fixedHeight)}>
-          {header && (
+          {header != null ? (
             <Dialog.Title tabIndex={-1} ref={initialFocusRef} className={styles.header}>
               {header}
             </Dialog.Title>
-          )}
-          <div tabIndex={-1} ref={header == null ? initialFocusRef : null} className={styles.contents}>
+          ) : <VisuallyHidden tabIndex={-1} ref={initialFocusRef}>ダイアログ</VisuallyHidden>}
+          <div className={styles.contents}>
             {children}
           </div>
           <Button block onClick={onClose} aria-label={closeLabel}>

--- a/src/components/MessageModal/MessageModal.tsx
+++ b/src/components/MessageModal/MessageModal.tsx
@@ -5,7 +5,7 @@ import clsx from 'clsx';
 import { FC, Fragment, PropsWithChildren, useCallback, useRef } from 'react';
 import styles from './MessageModal.module.css';
 import { Button } from '../../';
-import { VisuallyHidden } from "../../sharedComponents/VisuallyHidden/VisuallyHidden";
+import { VisuallyHidden } from '../../sharedComponents/VisuallyHidden/VisuallyHidden';
 import { CustomDataAttributeProps } from '../../types/attributes';
 import { opacityToClassName } from '../../utils/style';
 
@@ -108,10 +108,12 @@ export const MessageModal: FC<Props> = ({
             <Dialog.Title tabIndex={-1} ref={initialFocusRef} className={styles.header}>
               {header}
             </Dialog.Title>
-          ) : <VisuallyHidden tabIndex={-1} ref={initialFocusRef}>ダイアログ</VisuallyHidden>}
-          <div className={styles.contents}>
-            {children}
-          </div>
+          ) : (
+            <VisuallyHidden tabIndex={-1} ref={initialFocusRef}>
+              ダイアログ
+            </VisuallyHidden>
+          )}
+          <div className={styles.contents}>{children}</div>
           <Button block onClick={onClose} aria-label={closeLabel}>
             {closeLabel}
           </Button>

--- a/src/components/MessageModal/MessageModal.tsx
+++ b/src/components/MessageModal/MessageModal.tsx
@@ -2,7 +2,7 @@
 
 import { Dialog, Transition } from '@headlessui/react';
 import clsx from 'clsx';
-import {FC, Fragment, PropsWithChildren, useCallback, useRef} from 'react';
+import { FC, Fragment, PropsWithChildren, useCallback, useRef } from 'react';
 import styles from './MessageModal.module.css';
 import { Button } from '../../';
 import { CustomDataAttributeProps } from '../../types/attributes';
@@ -93,11 +93,24 @@ export const MessageModal: FC<Props> = ({
       leaveFrom={styles.panelLeaveFrom}
       leaveTo={styles.panelLeaveTo}
     >
-      <Dialog ref={dialogRef} static={isStatic} onClose={onClose} className={styles.modal} initialFocus={initialFocusRef} {...otherProps}>
+      <Dialog
+        ref={dialogRef}
+        static={isStatic}
+        onClose={onClose}
+        className={styles.modal}
+        initialFocus={initialFocusRef}
+        {...otherProps}
+      >
         <Dialog.Overlay className={clsx(styles.overlay, styles[opacityClassName])} />
         <div className={clsx(styles.modalBody, fixedHeight && styles.fixedHeight)}>
-          {header && <Dialog.Title tabIndex={-1} ref={initialFocusRef} className={styles.header}>{header}</Dialog.Title>}
-          <div tabIndex={-1} ref={header == null ? initialFocusRef : null} className={styles.contents}>{children}</div>
+          {header && (
+            <Dialog.Title tabIndex={-1} ref={initialFocusRef} className={styles.header}>
+              {header}
+            </Dialog.Title>
+          )}
+          <div tabIndex={-1} ref={header == null ? initialFocusRef : null} className={styles.contents}>
+            {children}
+          </div>
           <Button block onClick={onClose} aria-label={closeLabel}>
             {closeLabel}
           </Button>

--- a/src/sharedComponents/VisuallyHidden/VisuallyHidden.module.css
+++ b/src/sharedComponents/VisuallyHidden/VisuallyHidden.module.css
@@ -1,0 +1,15 @@
+.visuallyHidden {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border-width: 0;
+}
+
+.visuallyHidden[tabindex="-1"] {
+    outline: none;
+}

--- a/src/sharedComponents/VisuallyHidden/VisuallyHidden.module.css
+++ b/src/sharedComponents/VisuallyHidden/VisuallyHidden.module.css
@@ -1,15 +1,15 @@
 .visuallyHidden {
-    position: absolute;
-    width: 1px;
-    height: 1px;
-    padding: 0;
-    margin: -1px;
-    overflow: hidden;
-    clip: rect(0, 0, 0, 0);
-    white-space: nowrap;
-    border-width: 0;
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border-width: 0;
 }
 
-.visuallyHidden[tabindex="-1"] {
-    outline: none;
+.visuallyHidden[tabindex='-1'] {
+  outline: none;
 }

--- a/src/sharedComponents/VisuallyHidden/VisuallyHidden.tsx
+++ b/src/sharedComponents/VisuallyHidden/VisuallyHidden.tsx
@@ -1,0 +1,13 @@
+import styles from './VisuallyHidden.module.css';
+import type { PropsWithChildren } from "react";
+import { forwardRef } from "react";
+
+type Props = {
+    tabIndex?: number
+}
+
+export const VisuallyHidden = forwardRef<HTMLSpanElement, PropsWithChildren<Props>>(({ children, tabIndex }, ref) => {
+    return <span ref={ref} tabIndex={tabIndex} className={styles.visuallyHidden}>{children}</span>;
+})
+
+VisuallyHidden.displayName = 'VisuallyHidden';

--- a/src/sharedComponents/VisuallyHidden/VisuallyHidden.tsx
+++ b/src/sharedComponents/VisuallyHidden/VisuallyHidden.tsx
@@ -1,13 +1,17 @@
+import { forwardRef } from 'react';
 import styles from './VisuallyHidden.module.css';
-import type { PropsWithChildren } from "react";
-import { forwardRef } from "react";
+import type { PropsWithChildren } from 'react';
 
 type Props = {
-    tabIndex?: number
-}
+  tabIndex?: number;
+};
 
 export const VisuallyHidden = forwardRef<HTMLSpanElement, PropsWithChildren<Props>>(({ children, tabIndex }, ref) => {
-    return <span ref={ref} tabIndex={tabIndex} className={styles.visuallyHidden}>{children}</span>;
-})
+  return (
+    <span ref={ref} tabIndex={tabIndex} className={styles.visuallyHidden}>
+      {children}
+    </span>
+  );
+});
 
 VisuallyHidden.displayName = 'VisuallyHidden';


### PR DESCRIPTION
# Changes

- Longer content inside the modal was displayed in a scrolled state to allow the button to come into focus
- Change the initial focus to the header or the element it replaces
  -  This ensures that the modal's content is displayed from the top, even if it is long.
- Add Tests
- Tested with Chrome+VoiceOver.

# Screenshot

Even if there is long content inside the modal, it is displayed from the beginning.

## ActionHalfModal

![ActionHalfModal](https://github.com/ubie-oss/ubie-ui/assets/10903851/6dbe66eb-f87f-4c92-92df-cea176b446e6)

## ActionModal

![ActionModal](https://github.com/ubie-oss/ubie-ui/assets/10903851/3afc0a7f-2ecb-424a-b4e0-74a508b9ef0f)

## MessageHalfModal

![MessageHalfModal](https://github.com/ubie-oss/ubie-ui/assets/10903851/a862c762-a85a-4277-b0aa-527774a9ec2c)

## MessageModal

![MessageModal](https://github.com/ubie-oss/ubie-ui/assets/10903851/2aeb364f-0b12-432a-8fba-8d29aa6d1329)


# Check

- [ ] Added new Component
  - [ ] Added data-* prop and id prop
- [ ] Updated [Ubie Vitals](https://github.com/ubie-oss/ubie-vitals-website) or Added an update [issue](https://github.com/ubie-oss/ubie-vitals-website/issues)(if needed)

