### PR TITLE
Imple `<Icon>` component

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -57,14 +57,15 @@ module.exports = {
     'unused-imports/no-unused-imports': 'error',
     'import/no-unresolved': 'off',
     'no-console': 'error',
-    "@typescript-eslint/no-unused-vars": [
-      "error",
+    '@typescript-eslint/no-unused-vars': [
+      'error',
       {
-        "argsIgnorePattern": "_",
-        "varsIgnorePattern": "_",
-        "caughtErrorsIgnorePattern": "_",
-        "destructuredArrayIgnorePattern": "_"
-      }
-    ]
+        argsIgnorePattern: '_',
+        varsIgnorePattern: '_',
+        caughtErrorsIgnorePattern: '_',
+        destructuredArrayIgnorePattern: '_',
+      },
+    ],
+    'import/namespace': [2, { allowComputed: true }],
   },
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -7049,8 +7049,9 @@
     },
     "node_modules/@ubie/ubie-icons": {
       "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@ubie/ubie-icons/-/ubie-icons-0.5.0.tgz",
+      "integrity": "sha512-cA43rsLetzo2o4I1of1RYE0eYH3cwYQ3hGKvKDXYq2qWSCrHRP0aF5bYOX6bZjhz/WfH+HDKmCoTp2waigvw2Q==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "react": "^17.0.2",
         "react-dom": "^17.0.2"

--- a/package.json
+++ b/package.json
@@ -130,6 +130,7 @@
   "peerDependencies": {
     "@headlessui/react": ">1.7.0 <2.0.0",
     "@ubie/design-tokens": "^0.0.10 || ^0.1.0",
+    "@ubie/ubie-icons": ">0.5.0",
     "clsx": ">1.2.0",
     "react": "^17 || ^18",
     "react-dom": "^17 || ^18"

--- a/src/components/Button/Button.module.css
+++ b/src/components/Button/Button.module.css
@@ -225,7 +225,7 @@
 
 .icon > * {
   width: var(--icon-size);
-  height: var(--sicon-size);
+  height: var(--icon-size);
 }
 
 .fixedIcon {

--- a/src/components/Icon/Icon.module.css
+++ b/src/components/Icon/Icon.module.css
@@ -1,0 +1,6 @@
+.icon {
+  width: var(--size);
+  height: var(--size);
+  color: var(--text-color);
+  vertical-align: bottom;
+}

--- a/src/components/Icon/Icon.spec.tsx
+++ b/src/components/Icon/Icon.spec.tsx
@@ -1,0 +1,24 @@
+import { composeStory } from '@storybook/react';
+import { render, screen } from '@testing-library/react';
+import Meta, { WithCustomDataAttribute, WithId } from './Icon.stories';
+
+const WithCustomDataAttributeStory = composeStory(WithCustomDataAttribute, Meta);
+const WithIdStory = composeStory(WithId, Meta);
+
+describe('Icon', () => {
+  test('Add custom data attributes', async () => {
+    render(<WithCustomDataAttributeStory />);
+
+    const iconElement = await screen.findByRole('img');
+
+    expect(iconElement).toHaveAttribute('data-test-id', 'icon-custom-attribute');
+  });
+
+  test('Add id', async () => {
+    render(<WithIdStory />);
+
+    const iconElement = await screen.findByRole('img');
+
+    expect(iconElement).toHaveAttribute('id', 'icon-id');
+  });
+});

--- a/src/components/Icon/Icon.spec.tsx
+++ b/src/components/Icon/Icon.spec.tsx
@@ -9,15 +9,15 @@ describe('Icon', () => {
   test('Add custom data attributes', async () => {
     render(<WithCustomDataAttributeStory />);
 
-    const iconElement = await screen.findByRole('img');
+    const iconElement = await screen.findByTestId('testid');
 
-    expect(iconElement).toHaveAttribute('data-test-id', 'icon-custom-attribute');
+    expect(iconElement).toBeInTheDocument();
   });
 
   test('Add id', async () => {
     render(<WithIdStory />);
 
-    const iconElement = await screen.findByRole('img');
+    const iconElement = await screen.findByTestId('testid');
 
     expect(iconElement).toHaveAttribute('id', 'icon-id');
   });

--- a/src/components/Icon/Icon.stories.tsx
+++ b/src/components/Icon/Icon.stories.tsx
@@ -8,7 +8,6 @@ export default {
 
 const defaultArgs: Partial<ComponentProps<typeof Icon>> = {
   icon: 'UbieIcon',
-  label: 'ユビーのロゴ',
 };
 
 type Story = StoryObj<typeof Icon>;
@@ -55,14 +54,16 @@ export const Color: Story = {
   args: defaultArgs,
 };
 
-export const Decorative: Story = {
+export const CaseOnlyIcon: Story = {
   render: () => (
     <Stack spacing="sm">
       <p>
-        装飾的なアイコンの場合は、<code>ariaHidden</code> propをtrueとし、<code>label</code>には何も指定しません。
+        ラベルや付随する文章を伴わずにアイコン単独で使う場合、アイコンが保つ意味を<code>label</code> propで付与します
+        <br />
+        例: アイコンボタンなど
       </p>
       <div>
-        <Icon icon="AlertIcon" color="alert" ariaHidden /> 注意
+        <Icon icon="SetupIcon" label="設定" />
       </div>
     </Stack>
   ),
@@ -72,7 +73,7 @@ export const WithCustomDataAttribute: Story = {
   render: (args) => <Icon {...args} />,
   args: {
     ...defaultArgs,
-    'data-test-id': 'icon-custom-attribute',
+    'data-testid': 'testid',
   },
 };
 
@@ -81,5 +82,6 @@ export const WithId: Story = {
   args: {
     ...defaultArgs,
     id: 'icon-id',
+    'data-testid': 'testid',
   },
 };

--- a/src/components/Icon/Icon.stories.tsx
+++ b/src/components/Icon/Icon.stories.tsx
@@ -1,6 +1,6 @@
 import { Meta, StoryObj } from '@storybook/react';
 import { ComponentProps } from 'react';
-import { Icon, Flex, Box, Stack } from '../';
+import { Icon, Flex, Box, Stack } from '../../index';
 
 export default {
   component: Icon,
@@ -66,4 +66,20 @@ export const Decorative: Story = {
       </div>
     </Stack>
   ),
+};
+
+export const WithCustomDataAttribute: Story = {
+  render: (args) => <Icon {...args} />,
+  args: {
+    ...defaultArgs,
+    'data-test-id': 'icon-custom-attribute',
+  },
+};
+
+export const WithId: Story = {
+  render: (args) => <Icon {...args} />,
+  args: {
+    ...defaultArgs,
+    id: 'icon-id',
+  },
 };

--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -34,7 +34,7 @@ const toIconSizeEmValue = (size: IconSize): string => {
   }
 };
 
-type BaseProps = {
+type Props = {
   /**
    * アイコンの種類
    */
@@ -52,65 +52,23 @@ type BaseProps = {
    * ネイティブの`id`属性。ページで固有のIDを指定
    */
   id?: string;
-} & CustomDataAttributeProps;
-
-type DecorativeIcon = BaseProps & {
-  /**
-   * ariaHiddenがfalseの場合、アイコンはテキスト情報が必要です。labelを指定してください
-   * @default false
-   */
-  ariaHidden: true;
-};
-
-type InformativeIcon = BaseProps & {
-  /**
-   * ariaHiddenがfalseの場合、アイコンはテキスト情報が必要です。labelを指定してください
-   * @default false
-   */
-  ariaHidden?: false;
   /**
    * アイコンが何を表すかを説明するテキスト
+   * 単に装飾的なアイコンの場合は指定しない
    */
-  label: string;
-};
-type Props = DecorativeIcon | InformativeIcon;
-
-const extranctProps = (props: Props) => {
-  if (props.ariaHidden) {
-    const { icon, color, size = 'md', ariaHidden = false, ...otherProps } = props;
-    return {
-      icon,
-      color,
-      size,
-      ariaHidden,
-      label: undefined,
-      ...otherProps,
-    };
-  } else {
-    const { icon, color, size = 'md', ariaHidden = false, label, ...otherProps } = props;
-    return {
-      icon,
-      color,
-      size,
-      ariaHidden,
-      label,
-      ...otherProps,
-    };
-  }
-};
+  label?: string;
+} & CustomDataAttributeProps;
 
 /**
- * アイコンコンポーネント。個別のアイコンと比べ、最適化されています
+ * アイコンコンポーネント。labelを指定しない場合は単に装飾的なアイコンであるとみなされ、aria-hiddenが付与されます
  */
-export const Icon: FC<Props> = (props) => {
-  const { icon, color, size = 'md', ariaHidden = false, label, ...otherProps } = extranctProps(props);
-
+export const Icon: FC<Props> = ({ icon, color, size = 'md', label, ...otherProps }) => {
   const IconComponent = Icons[icon];
   const _sizeValue = toIconSizeEmValue(size);
   return (
     <IconComponent
       role="img"
-      aria-hidden={ariaHidden}
+      aria-hidden={label === undefined || label === '' ? true : undefined}
       aria-label={label}
       className={styles.icon}
       style={

--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -1,0 +1,104 @@
+import * as Icons from '@ubie/ubie-icons';
+import styles from './Icon.module.css';
+import { TextColor } from '../../types/style';
+import { colorVariable } from '../../utils/style';
+import type { FC, CSSProperties } from 'react';
+
+type Icon = keyof typeof Icons;
+
+type IconSize = 'xs' | 'sm' | 'md' | 'lg' | 'xl' | '2xl' | '3xl' | '4xl';
+
+const toIconSizeEmValue = (size: IconSize): string => {
+  switch (size) {
+    case 'xs':
+      return '1em';
+    case 'sm':
+      return '1.25em';
+    case 'md':
+      return '1.5em';
+    case 'lg':
+      return '1.75em';
+    case 'xl':
+      return '2em';
+    case '2xl':
+      return '4em';
+    case '3xl':
+      return '5em';
+    case '4xl':
+      return '6.5em';
+    default:
+      // eslint-disable-next-line no-case-declarations
+      const _: never = size;
+      throw new Error(`Unknown size: ${_}`);
+  }
+};
+
+type BaseProps = {
+  /**
+   * アイコンの種類
+   */
+  icon: Icon;
+  /**
+   * 色。指定しない場合はinheritとなり、親要素のfont-colorを継承します
+   */
+  color?: TextColor;
+  /**
+   * サイズ
+   * @default md
+   */
+  size?: IconSize;
+  /**
+   * ariaHiddenがfalseの場合、アイコンはテキスト情報が必要です。labelを指定してください
+   * @default false
+   */
+  ariaHidden?: boolean;
+  /**
+   * アイコンが何を表すかを説明するテキスト
+   */
+  label: string;
+};
+
+type CaseDecorative = {
+  /**
+   * ariaHiddenがfalseの場合、アイコンはテキスト情報が必要です。labelを指定してください
+   * @default false
+   */
+  ariaHidden: true;
+};
+
+type CaseInformative = {
+  /**
+   * ariaHiddenがfalseの場合、アイコンはテキスト情報が必要です。labelを指定してください
+   * @default false
+   */
+  ariaHidden?: false;
+  /**
+   * アイコンが何を表すかを説明するテキスト
+   */
+  label: string;
+};
+
+type DecorativeIcon = Omit<BaseProps, 'ariaHidden' | 'label'> & CaseDecorative;
+type InformativeIcon = Omit<BaseProps, 'ariaHidden' | 'label'> & CaseInformative;
+type Props = DecorativeIcon | InformativeIcon;
+
+/**
+ * アイコンコンポーネント。個別のアイコンと比べ、最適化されています
+ */
+export const Icon: FC<Props> = ({ icon, color, size = 'md', ariaHidden = false, label }) => {
+  const IconComponent = Icons[icon];
+  const _sizeValue = toIconSizeEmValue(size);
+  return (
+    <IconComponent
+      aria-hidden={ariaHidden}
+      aria-label={label}
+      className={styles.icon}
+      style={
+        {
+          ...colorVariable(color),
+          '--size': _sizeValue,
+        } as CSSProperties
+      }
+    />
+  );
+};

--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -109,6 +109,7 @@ export const Icon: FC<Props> = (props) => {
   const _sizeValue = toIconSizeEmValue(size);
   return (
     <IconComponent
+      role="img"
       aria-hidden={ariaHidden}
       aria-label={label}
       className={styles.icon}

--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -1,5 +1,6 @@
 import * as Icons from '@ubie/ubie-icons';
 import styles from './Icon.module.css';
+import { CustomDataAttributeProps } from '../../types/attributes';
 import { TextColor } from '../../types/style';
 import { colorVariable } from '../../utils/style';
 import type { FC, CSSProperties } from 'react';
@@ -48,17 +49,12 @@ type BaseProps = {
    */
   size?: IconSize;
   /**
-   * ariaHiddenがfalseの場合、アイコンはテキスト情報が必要です。labelを指定してください
-   * @default false
+   * ネイティブの`id`属性。ページで固有のIDを指定
    */
-  ariaHidden?: boolean;
-  /**
-   * アイコンが何を表すかを説明するテキスト
-   */
-  label: string;
-};
+  id?: string;
+} & CustomDataAttributeProps;
 
-type CaseDecorative = {
+type DecorativeIcon = BaseProps & {
   /**
    * ariaHiddenがfalseの場合、アイコンはテキスト情報が必要です。labelを指定してください
    * @default false
@@ -66,7 +62,7 @@ type CaseDecorative = {
   ariaHidden: true;
 };
 
-type CaseInformative = {
+type InformativeIcon = BaseProps & {
   /**
    * ariaHiddenがfalseの場合、アイコンはテキスト情報が必要です。labelを指定してください
    * @default false
@@ -77,15 +73,38 @@ type CaseInformative = {
    */
   label: string;
 };
-
-type DecorativeIcon = Omit<BaseProps, 'ariaHidden' | 'label'> & CaseDecorative;
-type InformativeIcon = Omit<BaseProps, 'ariaHidden' | 'label'> & CaseInformative;
 type Props = DecorativeIcon | InformativeIcon;
+
+const extranctProps = (props: Props) => {
+  if (props.ariaHidden) {
+    const { icon, color, size = 'md', ariaHidden = false, ...otherProps } = props;
+    return {
+      icon,
+      color,
+      size,
+      ariaHidden,
+      label: undefined,
+      ...otherProps,
+    };
+  } else {
+    const { icon, color, size = 'md', ariaHidden = false, label, ...otherProps } = props;
+    return {
+      icon,
+      color,
+      size,
+      ariaHidden,
+      label,
+      ...otherProps,
+    };
+  }
+};
 
 /**
  * アイコンコンポーネント。個別のアイコンと比べ、最適化されています
  */
-export const Icon: FC<Props> = ({ icon, color, size = 'md', ariaHidden = false, label }) => {
+export const Icon: FC<Props> = (props) => {
+  const { icon, color, size = 'md', ariaHidden = false, label, ...otherProps } = extranctProps(props);
+
   const IconComponent = Icons[icon];
   const _sizeValue = toIconSizeEmValue(size);
   return (
@@ -99,6 +118,7 @@ export const Icon: FC<Props> = ({ icon, color, size = 'md', ariaHidden = false, 
           '--size': _sizeValue,
         } as CSSProperties
       }
+      {...otherProps}
     />
   );
 };

--- a/src/components/LinkCard/LinkCard.module.css
+++ b/src/components/LinkCard/LinkCard.module.css
@@ -14,8 +14,13 @@
 
 .icon {
   flex: none;
-  font-size: var(--icon-size);
   color: var(--color-primary);
+}
+
+.icon > * {
+  width: var(--icon-size);
+  height: var(--icon-size);
+  vertical-align: bottom;
 }
 
 .text {

--- a/src/components/LinkCard/LinkCard.tsx
+++ b/src/components/LinkCard/LinkCard.tsx
@@ -2,9 +2,9 @@
 
 import { ArrowBRightIcon } from '@ubie/ubie-icons';
 import clsx from 'clsx';
-import { cloneElement, forwardRef } from 'react';
+import { cloneElement, forwardRef, isValidElement } from 'react';
 import styles from './LinkCard.module.css';
-import { CustomDataAttributeProps } from '../../types/attributes'; // 追加したインポート
+import { CustomDataAttributeProps } from '../../types/attributes';
 import type { ComponentType, ReactElement, ReactNode } from 'react';
 
 type Props = {
@@ -37,11 +37,29 @@ type Props = {
   /**
    * アイコン
    */
-  icon?: ComponentType<{ className?: string }>;
+  icon?: ComponentType | ReactElement;
 } & CustomDataAttributeProps;
 
+// ref https://github.com/microsoft/TypeScript/issues/53178
+const _isValidElement = (el: ComponentType | ReactElement): el is ReactElement => {
+  return isValidElement(el);
+};
+
+const renderPropIcon = (icon: ComponentType | ReactElement) => {
+  if (icon == null) {
+    return null;
+  }
+
+  if (_isValidElement(icon)) {
+    return icon;
+  }
+
+  const IconComponent = icon;
+  return <IconComponent />;
+};
+
 export const LinkCard = forwardRef<HTMLAnchorElement, Props>(
-  ({ title, size = 'medium', className, icon: IconComponent, description, render, ...props }, forwardedRef) => {
+  ({ title, size = 'medium', className, icon, description, render, ...props }, forwardedRef) => {
     const cls = clsx(styles[size], styles.card, className);
 
     /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
@@ -56,7 +74,7 @@ export const LinkCard = forwardRef<HTMLAnchorElement, Props>(
         ref: forwardedRef,
       },
       <>
-        {IconComponent && <IconComponent className={styles.icon} />}
+        {icon != null && <span className={styles.icon}>{renderPropIcon(icon)}</span>}
         <div className={styles.text}>
           <p className={styles.title}>{title}</p>
           {description && <p className={styles.description}>{description}</p>}

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ export { Flex } from './components/Flex/Flex';
 export { HelperMessage } from './components/HelperMessage/HelperMessage';
 export { Checkbox } from './components/Checkbox/Checkbox';
 export { CheckboxGroup } from './components/CheckboxGroup/CheckboxGroup';
+export { Icon } from './components/Icon/Icon';
 export { Input } from './components/Input/Input';
 export { Label } from './components/Label/Label';
 export { LinkCard } from './components/LinkCard/LinkCard';

--- a/src/stories/Button.stories.tsx
+++ b/src/stories/Button.stories.tsx
@@ -55,12 +55,12 @@ export const WithIcon: Story = {
         <dt style={{ fontWeight: 'bold' }}>Default Position</dt>
         <dd style={{ margin: 0 }}>
           <div style={{ display: 'flex', flexDirection: 'row', alignItems: 'flex-start', gap: '32px' }}>
-            <Button icon={<Icon icon="UbieIcon" ariaHidden />} {...defaultArgs} />
-            <Button icon={<Icon icon="UbieIcon" ariaHidden />} {...defaultArgs} variant="secondary" />
-            <Button icon={<Icon icon="UbieIcon" ariaHidden />} {...defaultArgs} variant="accent" />
-            <Button icon={<Icon icon="UbieIcon" ariaHidden />} {...defaultArgs} variant="alert" />
-            <Button icon={<Icon icon="UbieIcon" ariaHidden />} {...defaultArgs} variant="text" />
-            <Button icon={<Icon icon="TrashIcon" ariaHidden />} {...defaultArgs} variant="textAlert" />
+            <Button icon={<Icon icon="UbieIcon" />} {...defaultArgs} />
+            <Button icon={<Icon icon="UbieIcon" />} {...defaultArgs} variant="secondary" />
+            <Button icon={<Icon icon="UbieIcon" />} {...defaultArgs} variant="accent" />
+            <Button icon={<Icon icon="UbieIcon" />} {...defaultArgs} variant="alert" />
+            <Button icon={<Icon icon="UbieIcon" />} {...defaultArgs} variant="text" />
+            <Button icon={<Icon icon="TrashIcon" />} {...defaultArgs} variant="textAlert" />
           </div>
         </dd>
       </Stack>

--- a/src/stories/Button.stories.tsx
+++ b/src/stories/Button.stories.tsx
@@ -1,6 +1,6 @@
 import { Meta, StoryObj } from '@storybook/react';
-import { BlankLinkIcon, UbieIcon, TrashIcon } from '@ubie/ubie-icons';
-import { Button, Stack } from '../';
+import { BlankLinkIcon, TrashIcon } from '@ubie/ubie-icons';
+import { Button, Stack, Icon } from '../';
 import type { ComponentProps } from 'react';
 
 export default {
@@ -55,12 +55,12 @@ export const WithIcon: Story = {
         <dt style={{ fontWeight: 'bold' }}>Default Position</dt>
         <dd style={{ margin: 0 }}>
           <div style={{ display: 'flex', flexDirection: 'row', alignItems: 'flex-start', gap: '32px' }}>
-            <Button icon={<UbieIcon />} {...defaultArgs} />
-            <Button icon={<UbieIcon />} {...defaultArgs} variant="secondary" />
-            <Button icon={<UbieIcon />} {...defaultArgs} variant="accent" />
-            <Button icon={<UbieIcon />} {...defaultArgs} variant="alert" />
-            <Button icon={<UbieIcon />} {...defaultArgs} variant="text" />
-            <Button icon={<TrashIcon />} {...defaultArgs} variant="textAlert" />
+            <Button icon={<Icon icon="UbieIcon" ariaHidden />} {...defaultArgs} />
+            <Button icon={<Icon icon="UbieIcon" ariaHidden />} {...defaultArgs} variant="secondary" />
+            <Button icon={<Icon icon="UbieIcon" ariaHidden />} {...defaultArgs} variant="accent" />
+            <Button icon={<Icon icon="UbieIcon" ariaHidden />} {...defaultArgs} variant="alert" />
+            <Button icon={<Icon icon="UbieIcon" ariaHidden />} {...defaultArgs} variant="text" />
+            <Button icon={<Icon icon="TrashIcon" ariaHidden />} {...defaultArgs} variant="textAlert" />
           </div>
         </dd>
       </Stack>

--- a/src/stories/Icon.stories.tsx
+++ b/src/stories/Icon.stories.tsx
@@ -1,0 +1,69 @@
+import { Meta, StoryObj } from '@storybook/react';
+import { ComponentProps } from 'react';
+import { Icon, Flex, Box, Stack } from '../';
+
+export default {
+  component: Icon,
+} satisfies Meta<typeof Icon>;
+
+const defaultArgs: Partial<ComponentProps<typeof Icon>> = {
+  icon: 'UbieIcon',
+  label: 'ユビーのロゴ',
+};
+
+type Story = StoryObj<typeof Icon>;
+
+export const Default: Story = {
+  render: (args) => <Icon {...args} />,
+  args: defaultArgs,
+};
+
+export const Size: Story = {
+  render: (args) => (
+    <>
+      <Flex alignItems="center" spacing="sm">
+        <Icon {...args} size="xs" />
+        <Icon {...args} size="sm" />
+        <Icon {...args} size="md" />
+        <Icon {...args} size="lg" />
+        <Icon {...args} size="xl" />
+        <Icon {...args} size="2xl" />
+        <Icon {...args} size="3xl" />
+        <Icon {...args} size="4xl" />
+      </Flex>
+    </>
+  ),
+  args: defaultArgs,
+};
+
+export const Color: Story = {
+  render: (args) => (
+    <Flex alignItems="center" spacing="sm">
+      <Icon {...args} color="primary" />
+      <Icon {...args} color="accent" />
+      <Icon {...args} color="main" />
+      <Icon {...args} color="sub" />
+      <Icon {...args} color="alert" />
+      <Icon {...args} color="link" />
+      <Icon {...args} color="linkSub" />
+      <Icon {...args} color="disabled" />
+      <Box pt="xxs" pr="xxs" pb="xxs" pl="xxs" backgroundColor="primaryDarken">
+        <Icon {...args} color="white" />
+      </Box>
+    </Flex>
+  ),
+  args: defaultArgs,
+};
+
+export const Decorative: Story = {
+  render: () => (
+    <Stack spacing="sm">
+      <p>
+        装飾的なアイコンの場合は、<code>ariaHidden</code> propをtrueとし、<code>label</code>には何も指定しません。
+      </p>
+      <div>
+        <Icon icon="AlertIcon" color="alert" ariaHidden /> 注意
+      </div>
+    </Stack>
+  ),
+};

--- a/src/stories/LinkCard.stories.tsx
+++ b/src/stories/LinkCard.stories.tsx
@@ -26,7 +26,7 @@ export const WithIcon: Story = {
   render: (args) => (
     <Stack spacing="md">
       <LinkCard {...args} href="https://vitals.ubie.life/" icon={HospitalIcon} />
-      <LinkCard {...args} href="https://vitals.ubie.life/" icon={<Icon icon="HospitalIcon" ariaHidden />} />
+      <LinkCard {...args} href="https://vitals.ubie.life/" icon={<Icon icon="HospitalIcon" />} />
     </Stack>
   ),
   args: defaultArgs,

--- a/src/stories/LinkCard.stories.tsx
+++ b/src/stories/LinkCard.stories.tsx
@@ -1,6 +1,6 @@
 import { Meta, StoryObj } from '@storybook/react';
 import { HospitalIcon } from '@ubie/ubie-icons';
-import { LinkCard, Stack } from '..';
+import { LinkCard, Stack, Icon } from '..';
 
 export default {
   component: LinkCard,
@@ -23,7 +23,12 @@ export const Default: Story = {
 };
 
 export const WithIcon: Story = {
-  render: (args) => <LinkCard {...args} href="https://vitals.ubie.life/" icon={HospitalIcon} />,
+  render: (args) => (
+    <Stack spacing="md">
+      <LinkCard {...args} href="https://vitals.ubie.life/" icon={HospitalIcon} />
+      <LinkCard {...args} href="https://vitals.ubie.life/" icon={<Icon icon="HospitalIcon" ariaHidden />} />
+    </Stack>
+  ),
   args: defaultArgs,
 };
 


### PR DESCRIPTION
# Changes
- "Using @ubie/ubie-icon as is required CSS for styling.
- Implement components with styling features.
- Other components that use icons are supported by Icon components.

# Screenshot

http://localhost:6006/?path=/story/components-icon--size
![スクリーンショット 2024-05-30 18 20 45](https://github.com/ubie-oss/ubie-ui/assets/10903851/58c5cdaf-1178-42e1-a4d1-73b0bea9b585)

http://localhost:6006/?path=/story/components-icon--color
![スクリーンショット 2024-05-30 18 20 50](https://github.com/ubie-oss/ubie-ui/assets/10903851/677fc961-0ffd-4afb-867c-6d03af239c59)

http://localhost:6006/?path=/story/button-button--with-icon

![スクリーンショット 2024-05-30 18 21 45](https://github.com/ubie-oss/ubie-ui/assets/10903851/4173516d-fcee-4327-b207-d6c9010ac632)

The centre uses the Icon component.

http://localhost:6006/?path=/story/stories-linkcard--with-icon

![スクリーンショット 2024-05-30 18 22 49](https://github.com/ubie-oss/ubie-ui/assets/10903851/2938b17c-338d-44f4-b702-9763f2b0b4d4)

The top is using the Icon component.

# Check

- [x] Added new Component
  - [x] Added data-* prop and id prop
- [x] Updated [Ubie Vitals](https://github.com/ubie-oss/ubie-vitals-website) or Added an update [issue](https://github.com/ubie-oss/ubie-vitals-website/issues)(if needed)

