### PR TITLE
TextArea, Inputの重複した属性を削除

### DIFF
--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -7,10 +7,6 @@ import { CustomDataAttributeProps } from '../../types/attributes'; // 追加し�
 
 type Props = {
   /**
-   * ネイティブ要素の `id` 属性。ページで固有のIDを指定
-   */
-  id?: InputHTMLAttributes<HTMLInputElement>['id'];
-  /**
    * 有効でない入力を保持しているかどうか
    * @default false
    */
@@ -19,16 +15,7 @@ type Props = {
    * 値
    */
   value: string | number;
-  /**
-   * フィールドを無効化するかどうか
-   * @default false
-   */
-  disabled?: boolean;
-  /**
-   * 値が変化した場合のコールバック
-   */
-  onChange?: InputHTMLAttributes<HTMLInputElement>['onChange'];
-} & Omit<InputHTMLAttributes<HTMLInputElement>, 'id' | 'invalid' | 'value' | 'disabled' | 'onChange'> &
+} & Omit<InputHTMLAttributes<HTMLInputElement>, 'invalid' | 'value'> &
   CustomDataAttributeProps;
 
 export const Input: FC<Props> = forwardRef<HTMLInputElement, Props>(({ isInvalid, ...props }, ref) => {

--- a/src/components/TextArea/TextArea.tsx
+++ b/src/components/TextArea/TextArea.tsx
@@ -7,10 +7,6 @@ import { CustomDataAttributeProps } from '../../types/attributes';
 
 type Props = {
   /**
-   * ネイティブ要素の `id` 属性。ページで固有のIDを指定
-   */
-  id?: TextareaHTMLAttributes<HTMLTextAreaElement>['id'];
-  /**
    * 有効でない入力を保持しているかどうか
    * @default false
    */
@@ -24,11 +20,7 @@ type Props = {
    * @default false
    */
   disabled?: boolean;
-  /**
-   * 値が変化した場合のコールバック
-   */
-  onChange?: TextareaHTMLAttributes<HTMLTextAreaElement>['onChange'];
-} & Omit<TextareaHTMLAttributes<HTMLTextAreaElement>, 'id' | 'value' | 'onChange'> &
+} & Omit<TextareaHTMLAttributes<HTMLTextAreaElement>, 'value'> &
   CustomDataAttributeProps;
 
 export const TextArea: FC<Props> = ({ isInvalid = false, className, ...props }) => {


### PR DESCRIPTION
# Changes

TextArea, Inputについて、Propsで指定している属性と、Omitで除外している属性が重複していたので削除したい。
意図的に重複させているのであれば無視してください。

# Check

- [ ] Added new Component
  - [ ] Added data-* prop and id prop
- [ ] Updated [Ubie Vitals](https://github.com/ubie-oss/ubie-vitals-website) or Added an update [issue](https://github.com/ubie-oss/ubie-vitals-website/issues)(if needed)

