### PR TITLE
Add initial open prop to `<Accordion>`

### DIFF
--- a/src/components/Accordion/Accordion.stories.tsx
+++ b/src/components/Accordion/Accordion.stories.tsx
@@ -42,3 +42,11 @@ export const Id: Story = {
     </Accordion>
   ),
 };
+
+export const InitialOpen: Story = {
+  render: (args) => <Accordion {...args} />,
+  args: {
+    ...defaultArgs,
+    initialOpen: true,
+  },
+};

--- a/src/components/Accordion/Accordion.tsx
+++ b/src/components/Accordion/Accordion.tsx
@@ -26,6 +26,10 @@ type Props = {
    * 開閉をトリガーするsummary要素に付与するネイティブ要素の`id`属性。ページで固有のIDを指定
    */
   buttonId?: string;
+  /**
+   * 初期状態で開く
+   */
+  initialOpen?: boolean;
 } & CustomDataAttributeProps;
 
 export const Accordion: FC<PropsWithChildren<Props>> = ({
@@ -34,10 +38,11 @@ export const Accordion: FC<PropsWithChildren<Props>> = ({
   size = 'medium',
   id,
   buttonId,
+  initialOpen,
   ...props
 }) => {
   return (
-    <details className={clsx(styles.container, styles[size])} id={id} {...props}>
+    <details className={clsx(styles.container, styles[size])} id={id} {...props} open={initialOpen}>
       <summary id={buttonId} className={styles.button}>
         <span>{header}</span>
         <ArrowBDownIcon aria-hidden className={styles.arrow} />


### PR DESCRIPTION
# Changes

- Support use cases that I want to open from the beginning.

https://github.com/ubie-oss/ubie-ui/assets/10903851/8e0b0623-2ede-47ad-9b73-011a9fcfc9b6

# Check

- [ ] Added new Component
  - [ ] Added data-* prop and id prop
- [ ] Updated [Ubie Vitals](https://github.com/ubie-oss/ubie-vitals-website) or Added an update [issue](https://github.com/ubie-oss/ubie-vitals-website/issues)(if needed)

