### PR TITLE
Use :user-invalid instead of :invalid

### DIFF
--- a/src/components/Input/Input.module.css
+++ b/src/components/Input/Input.module.css
@@ -16,9 +16,16 @@
 }
 
 .input.isInvalid,
-.input:invalid {
+.input:user-invalid {
   background: var(--color-background-accent-darken);
   border-bottom-color: var(--color-alert-darken);
+}
+
+@supports not (selector(:user-invalid)) {
+  .input:invalid {
+    background: var(--color-background-accent-darken);
+    border-bottom-color: var(--color-alert-darken);
+  }
 }
 
 .input:disabled {

--- a/src/stories/Input.stories.tsx
+++ b/src/stories/Input.stories.tsx
@@ -115,6 +115,19 @@ export const Disabled: Story = {
 export const IsInvalid: Story = {
   render: () => <Input value="wrong value" isInvalid />,
 };
+
+export const Required: Story = {
+  render: () => {
+    const [value, setValue] = useState('');
+
+    const onChangeValue: ChangeEventHandler<HTMLInputElement> = useCallback((event) => {
+      setValue(event.target.value);
+    }, []);
+
+    return <Input required value={value} onChange={onChangeValue} />;
+  },
+};
+
 export const CustomDataAttribute: Story = {
   args: {
     'data-test-id': 'input-custom-attribute',


### PR DESCRIPTION
# Changes

Although :valid is used when Input is invalid, :valid fires before and during user input. It would be better to use :user-invalid, which fires after input is complete, as it is supported by all browsers.

Inputが無効のときに:validが使われているが、:validだとユーザーの入力前や入力中にも発火してしまう。入力完了後に発火する:user-invalidが全ブラウザで対応しているのでこちらを使ったほうが良いのではないでしょうか。

https://caniuse.com/mdn-css_selectors_user-invalid


## Screenshots


```tsx
export const Required: Story = {
  render: () => {
    const [value, setValue] = useState('');

    const onChangeValue: ChangeEventHandler<HTMLInputElement> = useCallback((event) => {
      setValue(event.target.value);
    }, []);

    return <Input required value={value} onChange={onChangeValue} />;
  },
};

```

Before

https://github.com/ubie-oss/ubie-ui/assets/10419447/8c8c7c7d-db21-4b43-94c7-e91cf1c63edd


After

https://github.com/ubie-oss/ubie-ui/assets/10419447/0124195a-442a-43dd-99af-87b2b48322d2



# Check

- [ ] Added new Component
  - [ ] Added data-* prop and id prop
- [ ] Updated [Ubie Vitals](https://github.com/ubie-oss/ubie-vitals-website) or Added an update [issue](https://github.com/ubie-oss/ubie-vitals-website/issues)(if needed)

