### PR TITLE
Make value not required for Input and Textarea

### DIFF
--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -11,11 +11,7 @@ type Props = {
    * @default false
    */
   isInvalid?: boolean;
-  /**
-   * 値
-   */
-  value: string | number;
-} & Omit<InputHTMLAttributes<HTMLInputElement>, 'invalid' | 'value'> &
+} & Omit<InputHTMLAttributes<HTMLInputElement>, 'invalid'> &
   CustomDataAttributeProps;
 
 export const Input = forwardRef<HTMLInputElement, Props>(({ isInvalid, ...props }, ref) => {

--- a/src/components/TextArea/TextArea.tsx
+++ b/src/components/TextArea/TextArea.tsx
@@ -13,15 +13,11 @@ type Props = {
    */
   isInvalid?: boolean;
   /**
-   * 値
-   */
-  value: string;
-  /**
    * フィールドを無効化するかどうか
    * @default false
    */
   disabled?: boolean;
-} & Omit<TextareaHTMLAttributes<HTMLTextAreaElement>, 'value'> &
+} & TextareaHTMLAttributes<HTMLTextAreaElement> &
   CustomDataAttributeProps;
 
 export const TextArea = forwardRef<HTMLTextAreaElement, Props>(({ isInvalid = false, className, ...props }, ref) => {


### PR DESCRIPTION
# Changes

Reason
- Standard input element does not require a value.
- Incompatible with form libraries such as react-use-form

- 標準のinput要素はvalueが必須じゃない
- react-use-formのようなフォームライブラリと相性が悪い

# Check

- [ ] Added new Component
  - [ ] Added data-* prop and id prop
- [ ] Updated [Ubie Vitals](https://github.com/ubie-oss/ubie-vitals-website) or Added an update [issue](https://github.com/ubie-oss/ubie-vitals-website/issues)(if needed)

