### PR TITLE
chore: add gapVariables & fix Stack

### DIFF
--- a/src/components/Flex/Flex.tsx
+++ b/src/components/Flex/Flex.tsx
@@ -5,7 +5,7 @@ import { isValidElement, cloneElement } from 'react';
 import styles from './Flex.module.css';
 import { CustomDataAttributeProps } from '../../types/attributes'; // 追加したインポート
 import { Spacing, AlignItems, JustifyContent, FlexDirection } from '../../types/style';
-import { paddingVariables, marginVariables } from '../../utils/style';
+import { paddingVariables, marginVariables, gapVariables } from '../../utils/style';
 import { HTMLTagname } from '../../utils/types';
 import { Box } from '../Box/Box';
 import type { PaddingProps, MarginProps } from '../../types/style';
@@ -80,9 +80,6 @@ export const Flex: FC<PropsWithChildren<Props>> = ({
   ml,
   ...otherProps
 }) => {
-  // Directly specifying the markuplint will result in a markuplint error.
-  const gapStyle = spacing ? `var(--size-spacing-${spacing})` : '0';
-
   /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
   const createElement = (props: any, children: ReactNode) => {
     if (isValidElement(FlexCopmonent)) {
@@ -96,11 +93,11 @@ export const Flex: FC<PropsWithChildren<Props>> = ({
     {
       className: clsx(styles.flex, height === 'full' && styles.heightFull, width === 'full' && styles.widthFull),
       style: {
-        '--gap': gapStyle,
         '--flex-direction': direction,
         '--align-items': alignItems,
         '--justify-content': justifyContent,
         '--flex-wrap': wrap ? 'wrap' : 'nowrap',
+        ...gapVariables(spacing),
         ...paddingVariables({
           p,
           px,

--- a/src/components/Stack/Stack.module.css
+++ b/src/components/Stack/Stack.module.css
@@ -1,6 +1,7 @@
 .stack {
   display: flex;
   flex-direction: column;
+  gap: var(--gap);
   padding: var(--padding-top) var(--padding-right) var(--padding-bottom) var(--padding-left);
   margin: var(--margin-top) var(--margin-right) var(--margin-bottom) var(--margin-left);
 }

--- a/src/components/Stack/Stack.tsx
+++ b/src/components/Stack/Stack.tsx
@@ -5,7 +5,7 @@ import { isValidElement, cloneElement } from 'react';
 import styles from './Stack.module.css';
 import { CustomDataAttributeProps } from '../../types/attributes'; // 追加したインポート
 import { Spacing, AlignItems, JustifyContent } from '../../types/style';
-import { paddingVariables, marginVariables } from '../../utils/style';
+import { paddingVariables, marginVariables, gapVariables } from '../../utils/style';
 import { HTMLTagname } from '../../utils/types';
 import { Box } from '../Box/Box';
 import type { PaddingProps, MarginProps } from '../../types/style';
@@ -21,7 +21,7 @@ type Props = {
    * 子要素の間隔
    * xxs=4px, xs=8px, sm=12px, md=16px, lg=24px, xl=40px, xxl=64px
    */
-  spacing: Spacing;
+  spacing?: Spacing;
   /**
    * 水平方向における子要素のレイアウトを定める。
    * @default stretch
@@ -87,7 +87,7 @@ export const Stack: FC<Props> = ({
       style: {
         alignItems: `${alignItems}`,
         justifyContent: `${justifyContent}`,
-        gap: `var(--size-spacing-${spacing})`,
+        ...gapVariables(spacing),
         ...paddingVariables({
           p,
           px,

--- a/src/utils/style.ts
+++ b/src/utils/style.ts
@@ -230,3 +230,12 @@ export const radiusVariables = (radius?: Radius) => {
     '--radius': radius ? createRadiusVariableFromKey(radius) : '0',
   } as CSSProperties;
 };
+
+/**
+ * Accepts optional arguments to unify default values.
+ */
+export const gapVariables = (spacing?: Spacing) => {
+  return {
+    '--gap': spacing ? `var(--size-spacing-${spacing})` : '0',
+  } as CSSProperties;
+};


### PR DESCRIPTION
# Changes
- Modified `Stack` to work even when spacing is not specified.
- Created a `gapVariables` function to unify processing with `Flex`.

# Check

- [ ] Added new Component
  - [ ] Added data-* prop and id prop
- [ ] Updated [Ubie Vitals](https://github.com/ubie-oss/ubie-vitals-website) or Added an update [issue](https://github.com/ubie-oss/ubie-vitals-website/issues)(if needed)

