### PR TITLE
When laying out checkboxes, etc. horizontally, enable wrapping to prevent layout breakdowns.

### DIFF
--- a/src/components/Checkbox/Checkbox.stories.tsx
+++ b/src/components/Checkbox/Checkbox.stories.tsx
@@ -10,7 +10,7 @@ export default {
 
 type Story = StoryObj<typeof Checkbox>;
 
-const options = ['option1', 'option2', 'option3'];
+const options = ['option1', 'option2', 'option3', 'option4', 'option5'];
 
 export const Default: Story = {
   render: () => {

--- a/src/components/CheckboxCard/CheckboxCard.stories.tsx
+++ b/src/components/CheckboxCard/CheckboxCard.stories.tsx
@@ -11,7 +11,7 @@ export default {
 
 const defaultArgs: Partial<ComponentProps<typeof CheckboxCard>> = {};
 
-const options = ['option1', 'option2', 'option3'];
+const options = ['option1', 'option2', 'option3', 'option4', 'option5'];
 
 type Story = StoryObj<typeof CheckboxCard>;
 
@@ -35,6 +35,7 @@ export const Default: Story = {
         <CheckboxGroup label="Checkbox">
           {options.map((option) => (
             <CheckboxCard
+              block
               name="default"
               value={option}
               onChange={onChange}

--- a/src/components/CheckboxGroup/CheckboxGroup.tsx
+++ b/src/components/CheckboxGroup/CheckboxGroup.tsx
@@ -41,6 +41,10 @@ export const CheckboxGroup = forwardRef<HTMLFieldSetElement, Props>(
       return includesCheckboxCard(children) ? 'sm' : 'md';
     }, [children]);
 
+    const wrap = useMemo(() => {
+      return direction === 'row';
+    }, [direction]);
+
     return (
       <fieldset className={styles.wrapper} ref={ref} {...otherProps}>
         {label && (
@@ -49,7 +53,7 @@ export const CheckboxGroup = forwardRef<HTMLFieldSetElement, Props>(
             {showRequiredLabel && <RequiredLabel />}
           </legend>
         )}
-        <Flex spacing={spacing} direction={direction}>
+        <Flex spacing={spacing} direction={direction} wrap={wrap}>
           {children}
         </Flex>
       </fieldset>

--- a/src/components/RadioGroup/RadioGroup.tsx
+++ b/src/components/RadioGroup/RadioGroup.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { forwardRef } from 'react';
+import { forwardRef, useMemo } from 'react';
 import styles from './RadioGroup.module.css';
 import { RequiredLabel } from '../../sharedComponents/RequiredLabel/RequiredLabel';
 import { CustomDataAttributeProps } from '../../types/attributes'; // 追加したインポート
@@ -32,6 +32,10 @@ export const RadioGroup = forwardRef<HTMLFieldSetElement, Props>(
     const childrenIsCard = children.some((child) => child.type === RadioCard);
     const childenIsBlock = direction === 'row' || (childrenIsCard && direction === 'column');
 
+    const wrap = useMemo(() => {
+      return direction === 'row';
+    }, [direction]);
+
     return (
       <fieldset className={styles.wrapper} ref={ref} {...otherProps}>
         {label && (
@@ -44,6 +48,7 @@ export const RadioGroup = forwardRef<HTMLFieldSetElement, Props>(
           spacing={childrenIsCard ? 'sm' : 'md'}
           alignItems={childenIsBlock ? 'normal' : undefined}
           direction={direction}
+          wrap={wrap}
         >
           {children}
         </Flex>

--- a/src/types/style.ts
+++ b/src/types/style.ts
@@ -30,7 +30,7 @@ export type Spacing = 'xxs' | 'xs' | 'sm' | 'md' | 'lg' | 'xl' | 'xxl';
 
 export type PaddingProps = {
   /**
-   * 四方のパディングを一括で設定。Spacing Tokenのキーを指定\
+   * 四方のパディングを一括で設定。Spacing Tokenのキーを指定
    * xxs=4px, xs=8px, sm=12px, md=16px, lg=24px, xl=40px, xxl=64px
    */
   p?: Spacing;


### PR DESCRIPTION
# Changes

- CherckboxGroup & RadioGruop
- Turn on internal wrap when direction="row".

# Movie


https://github.com/ubie-oss/ubie-ui/assets/10903851/0746b240-b21f-40c1-b63d-0a2067041cb7


https://github.com/ubie-oss/ubie-ui/assets/10903851/bfb61c69-3cdc-4a53-b340-c428d9dba2c4



# Check

- [ ] Added new Component
  - [ ] Added data-* prop and id prop
- [ ] Updated [Ubie Vitals](https://github.com/ubie-oss/ubie-vitals-website) or Added an update [issue](https://github.com/ubie-oss/ubie-vitals-website/issues)(if needed)

