### PR TITLE
imple `as` and `render` prop in `<Text>`

### DIFF
--- a/.markuplintrc
+++ b/.markuplintrc
@@ -7,5 +7,13 @@
   },
   "specs": {
     ".tsx$": "@markuplint/react-spec"
-  }
+  },
+  "nodeRules": [
+    {
+      "selector": "button",
+      "rules": {
+        "require-accessible-name": false
+      }
+    }
+  ]
 }

--- a/src/components/Text/Text.module.css
+++ b/src/components/Text/Text.module.css
@@ -12,6 +12,24 @@
   margin-bottom: 0;
 }
 
+a.text {
+  text-decoration: underline;
+}
+
+@media (hover:hover) {
+  a.text:hover {
+    text-decoration: none;
+  }
+}
+
+a.text:focus-visible {
+  text-decoration: none;
+}
+
+a.text:active {
+  text-decoration: underline;
+}
+
 .bold {
   font-weight: bold;
 }

--- a/src/components/Text/Text.module.css
+++ b/src/components/Text/Text.module.css
@@ -16,7 +16,7 @@ a.text {
   text-decoration: underline;
 }
 
-@media (hover:hover) {
+@media (hover: hover) {
   a.text:hover {
     text-decoration: none;
   }
@@ -45,11 +45,10 @@ button.text.link:focus-visible {
     color: var(--color-primary-darken);
   }
 
-  button.text.link:active{
+  button.text.link:active {
     color: var(--color-text-link);
   }
 }
-
 
 .bold {
   font-weight: bold;

--- a/src/components/Text/Text.module.css
+++ b/src/components/Text/Text.module.css
@@ -30,6 +30,27 @@ a.text:active {
   text-decoration: underline;
 }
 
+button.text {
+  padding: 0;
+  background-color: transparent;
+  border: none;
+}
+
+button.text.link:focus-visible {
+  color: var(--color-primary-darken);
+}
+
+@media (hover: hover) {
+  button.text.link:hover {
+    color: var(--color-primary-darken);
+  }
+
+  button.text.link:active{
+    color: var(--color-text-link);
+  }
+}
+
+
 .bold {
   font-weight: bold;
 }

--- a/src/stories/Text.stories.tsx
+++ b/src/stories/Text.stories.tsx
@@ -398,3 +398,15 @@ export const AsLink: Story = {
     </>
   ),
 };
+
+export const AsButton: Story = {
+  render: () => (
+    <>
+      <p>as propを使うと、type propが重複してしまう。ハッキ―だがrenderで回避</p>
+      <p>button要素に対してmarkuplintのrequire-accessible-nameを無効化する必要があります</p>
+      <Text type="heading" size="xl" bold render={<button type="button" />}>
+        ボタン
+      </Text>
+    </>
+  ),
+};

--- a/src/stories/Text.stories.tsx
+++ b/src/stories/Text.stories.tsx
@@ -377,3 +377,11 @@ export const Wrap: Story = {
     </div>
   ),
 };
+
+export const AsLink: Story = {
+  render: () => (
+    <Text as="a" href="https://vitals.ubie.life/">
+      Link ggggg(underline確認でgをおいている)
+    </Text>
+  ),
+};

--- a/src/stories/Text.stories.tsx
+++ b/src/stories/Text.stories.tsx
@@ -1,5 +1,6 @@
 import { Meta, StoryObj } from '@storybook/react';
 import { Text, Flex, Stack, Box } from '../';
+import type { FC, PropsWithChildren } from 'react';
 
 export default {
   title: 'Typography/Text',
@@ -378,10 +379,22 @@ export const Wrap: Story = {
   ),
 };
 
+const TestLink: FC<PropsWithChildren<{ href: string }>> = ({ href, children, ...rest }) => (
+  <a href={href} {...rest}>
+    {children}
+  </a>
+);
+
 export const AsLink: Story = {
   render: () => (
-    <Text as="a" href="https://vitals.ubie.life/">
-      Link ggggg(underline確認でgをおいている)
-    </Text>
+    <>
+      <Text as="a" href="https://vitals.ubie.life/">
+        Link ggggg(underline確認でgをおいている)
+      </Text>
+      <br />
+      <Text type="heading" size="xl" bold render={<TestLink href="https://vitals.ubie.life/" />}>
+        render propを使用したケース
+      </Text>
+    </>
   ),
 };


### PR DESCRIPTION
# Changes

- imple `as` and `render` prop in `<Text>`
- to be able to use it as `link`
- to be able to use it as `button`
  - However, use `render` prop to avoid `type` duplication.

# Check

- [ ] Added new Component
  - [ ] Added data-* prop and id prop
- [ ] Updated [Ubie Vitals](https://github.com/ubie-oss/ubie-vitals-website) or Added an update [issue](https://github.com/ubie-oss/ubie-vitals-website/issues)(if needed)

