### PR TITLE
fix ButtonCard color style

### DIFF
--- a/src/components/ButtonCard/ButtonCard.module.css
+++ b/src/components/ButtonCard/ButtonCard.module.css
@@ -11,6 +11,7 @@
 
   /* TODO: Replaced by tokens when @ubie/design-tokens is up-to-date. */
   line-height: 1.5;
+  color: var(--color-text-main);
   text-decoration: none;
   overflow-wrap: anywhere;
   cursor: pointer;


### PR DESCRIPTION
# Changes
- add color-text-main to ButtonCard
  - Fixed an issue where the text color was set to the default link color in Safari.

# Check

- [ ] Added new Component
  - [ ] Added data-* prop and id prop
- [ ] Updated [Ubie Vitals](https://github.com/ubie-oss/ubie-vitals-website) or Added an update [issue](https://github.com/ubie-oss/ubie-vitals-website/issues)(if needed)

