### PR TITLE
Text is not centered when wrap on ButtonCard

### DIFF
--- a/src/components/ButtonCard/ButtonCard.module.css
+++ b/src/components/ButtonCard/ButtonCard.module.css
@@ -11,6 +11,7 @@
 
   /* TODO: Replaced by tokens when @ubie/design-tokens is up-to-date. */
   line-height: 1.5;
+  text-align: left;
   text-decoration: none;
   overflow-wrap: anywhere;
   cursor: pointer;

--- a/src/components/ButtonCard/ButtonCard.stories.tsx
+++ b/src/components/ButtonCard/ButtonCard.stories.tsx
@@ -1,6 +1,7 @@
 import { action } from '@storybook/addon-actions';
 import { Meta, StoryObj } from '@storybook/react';
 import { ButtonCard } from './ButtonCard';
+import { Box } from '../Box/Box';
 import { Flex } from '../Flex/Flex';
 
 export default {
@@ -19,6 +20,18 @@ type Story = StoryObj<typeof ButtonCard>;
 export const Default: Story = {
   render: (args) => <ButtonCard {...args} />,
   args: defaultArgs,
+};
+
+export const WrapText: Story = {
+  render: (args) => (
+    <Box width="200px">
+      <ButtonCard {...args} />
+    </Box>
+  ),
+  args: {
+    ...defaultArgs,
+    children: '自分自分自分自分自分自分自分自分自分自分自分自分自分自分自分自分',
+  },
 };
 
 export const Disabled: Story = {


### PR DESCRIPTION
# Changes

before:
<img width="459" alt="スクリーンショット 2024-07-26 10 28 00" src="https://github.com/user-attachments/assets/4a9f195c-f327-41ba-a793-bf8ced924975">

after:
<img width="407" alt="スクリーンショット 2024-07-26 10 28 54" src="https://github.com/user-attachments/assets/5f732234-fb58-448f-8b2b-359501088d89">

# Check

- [ ] Added new Component
  - [ ] Added data-* prop and id prop
- [ ] Updated [Ubie Vitals](https://github.com/ubie-oss/ubie-vitals-website) or Added an update [issue](https://github.com/ubie-oss/ubie-vitals-website/issues)(if needed)

