### PR TITLE
Fixed the ButtonCard's padding to match Figma

### DIFF
--- a/src/components/ButtonCard/ButtonCard.module.css
+++ b/src/components/ButtonCard/ButtonCard.module.css
@@ -4,7 +4,7 @@
   display: flex;
   align-items: center;
   width: 100%;
-  padding: var(--size-spacing-md);
+  padding: var(--size-spacing-md) var(--size-spacing-sm);
   font-size: var(--text-button-lg-size);
   font-weight: bold;
   hyphens: auto;


### PR DESCRIPTION
# Changes

<img width="997" alt="スクリーンショット 2024-07-26 16 38 02" src="https://github.com/user-attachments/assets/d3e96164-fdbb-41b8-a5c4-287af6b90f2e">

The left and right padding should be 12px.

# Check

- [ ] Added new Component
  - [ ] Added data-* prop and id prop
- [ ] Updated [Ubie Vitals](https://github.com/ubie-oss/ubie-vitals-website) or Added an update [issue](https://github.com/ubie-oss/ubie-vitals-website/issues)(if needed)

