### PR TITLE
Allow installation of ubie-icons above v0.8.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,6 @@
         "@typescript-eslint/parser": "5.62.0",
         "@ubie/design-tokens": "0.1.4",
         "@ubie/prettier-config": "0.1.0",
-        "@ubie/ubie-icons": "^0.6.1",
         "@vitejs/plugin-react": "^4.2.1",
         "@vitejs/plugin-react-swc": "^3.6.0",
         "autoprefixer": "10.4.15",
@@ -83,7 +82,7 @@
       "peerDependencies": {
         "@headlessui/react": ">1.7.0 <2.0.0",
         "@ubie/design-tokens": "^0.0.10 || ^0.1.0",
-        "@ubie/ubie-icons": ">=0.5.0 <0.6.2",
+        "@ubie/ubie-icons": ">=0.5.0 <0.6.2 || >=0.8.0",
         "clsx": ">1.2.0",
         "react": "^17 || ^18",
         "react-dom": "^17 || ^18"
@@ -7108,7 +7107,7 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/@ubie/ubie-icons/-/ubie-icons-0.6.1.tgz",
       "integrity": "sha512-ubgylFbxfdRimGdmBkCKfrIBGBFiutUBXxB98bbsrbVac7Xlx0hPunceEAyk3IeOur//1gDARhLanrpbBA0gGQ==",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "react": "^17.0.2",
         "react-dom": "^17.0.2"
@@ -7118,7 +7117,7 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
       "integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"
@@ -7131,7 +7130,7 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-17.0.2.tgz",
       "integrity": "sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
@@ -7145,7 +7144,7 @@
       "version": "0.20.2",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.20.2.tgz",
       "integrity": "sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"
@@ -14599,7 +14598,6 @@
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/js-yaml": {
@@ -15472,7 +15470,6 @@
     },
     "node_modules/loose-envify": {
       "version": "1.4.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
@@ -17301,7 +17298,6 @@
     },
     "node_modules/object-assign": {
       "version": "4.1.1",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"

--- a/package.json
+++ b/package.json
@@ -84,7 +84,6 @@
     "@typescript-eslint/parser": "5.62.0",
     "@ubie/design-tokens": "0.1.4",
     "@ubie/prettier-config": "0.1.0",
-    "@ubie/ubie-icons": "^0.6.1",
     "@vitejs/plugin-react": "^4.2.1",
     "@vitejs/plugin-react-swc": "^3.6.0",
     "autoprefixer": "10.4.15",
@@ -129,7 +128,7 @@
   "peerDependencies": {
     "@headlessui/react": ">1.7.0 <2.0.0",
     "@ubie/design-tokens": "^0.0.10 || ^0.1.0",
-    "@ubie/ubie-icons": ">=0.5.0 <0.6.2",
+    "@ubie/ubie-icons": ">=0.5.0 <0.6.2 || >=0.8.0",
     "clsx": ">1.2.0",
     "react": "^17 || ^18",
     "react-dom": "^17 || ^18"


### PR DESCRIPTION
# Changes

- Allow installation of ubie-icons above v0.8.0
- Temporarily installed in another repository and verified

# Check

- [ ] Browser verification (minimum) Android Chrome/iOS Safari(375px-)
- [ ] CSS not affected by inheritance
- [ ] Layout does not break even if there is an overflow
- [ ] Layout does not break when wraps
- [ ] Added new Component
  - [ ] Added data-* prop and id prop
- [ ] Updated [Ubie Vitals](https://github.com/ubie-oss/ubie-vitals-website) or Added an update [issue](https://github.com/ubie-oss/ubie-vitals-website/issues)(if needed)

