### PR TITLE
Allow icon prop to be specified by name

### DIFF
--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -3,7 +3,7 @@
 import { clsx } from 'clsx';
 import { type CSSProperties, forwardRef } from 'react';
 import styles from './Button.module.css';
-import { VariantIcon } from './VariantIcon';
+import { useIcon } from './useIcon';
 import { marginVariables } from '../../utils/style';
 import type { ButtonProps } from './ButtonTypes';
 
@@ -34,9 +34,9 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
     },
     ref,
   ) => {
-    const icon = _icon === 'default' ? <VariantIcon variant={variant} /> : _icon;
-    const fixedIcon = _fixedIcon === 'default' ? <VariantIcon variant={variant} /> : _fixedIcon;
-    const suffixIcon = _suffixIcon === 'default' ? <VariantIcon variant={variant} /> : _suffixIcon;
+    const icon = useIcon(_icon, variant);
+    const fixedIcon = useIcon(_fixedIcon, variant);
+    const suffixIcon = useIcon(_suffixIcon, variant);
     const cls = clsx({
       [styles.button]: true,
       [styles[variant]]: true,

--- a/src/components/Button/ButtonTypes.ts
+++ b/src/components/Button/ButtonTypes.ts
@@ -1,4 +1,5 @@
 import { CustomDataAttributeProps } from '../../types/attributes';
+import { IconName } from '../../types/icon';
 import type { MarginProps } from '../../types/style';
 import type { AnchorHTMLAttributes, ButtonHTMLAttributes, ReactElement, ReactNode } from 'react';
 
@@ -34,15 +35,15 @@ export type BaseProps = {
   /**
    * アイコン
    */
-  icon?: 'default' | ReactNode;
+  icon?: 'default' | ReactElement | IconName;
   /**
    * Fixedアイコン
    */
-  fixedIcon?: 'default' | ReactNode;
+  fixedIcon?: 'default' | ReactElement | IconName;
   /**
    * 後方配置のアイコン
    */
-  suffixIcon?: 'default' | ReactNode;
+  suffixIcon?: 'default' | ReactElement | IconName;
   /**
    * ラベルの折り返しを指定
    */

--- a/src/components/Button/LinkButton.tsx
+++ b/src/components/Button/LinkButton.tsx
@@ -3,7 +3,7 @@
 import clsx from 'clsx';
 import { cloneElement, CSSProperties, forwardRef } from 'react';
 import styles from './Button.module.css';
-import { VariantIcon } from './VariantIcon';
+import { useIcon } from './useIcon';
 import { marginVariables } from '../../utils/style';
 import type { LinkButtonProps } from './ButtonTypes';
 import type { ReactNode } from 'react';
@@ -31,9 +31,9 @@ export const LinkButton = forwardRef<HTMLAnchorElement, LinkButtonProps>(
     },
     forwardedRef,
   ) => {
-    const icon = _icon === 'default' ? <VariantIcon variant={variant} /> : _icon;
-    const fixedIcon = _fixedIcon === 'default' ? <VariantIcon variant={variant} /> : _fixedIcon;
-    const suffixIcon = _suffixIcon === 'default' ? <VariantIcon variant={variant} /> : _suffixIcon;
+    const icon = useIcon(_icon, variant);
+    const fixedIcon = useIcon(_fixedIcon, variant);
+    const suffixIcon = useIcon(_suffixIcon, variant);
     const cls = clsx({
       [styles.button]: true,
       [styles[variant]]: true,

--- a/src/components/Button/useIcon.tsx
+++ b/src/components/Button/useIcon.tsx
@@ -1,0 +1,16 @@
+import { useMemo } from 'react';
+import { VariantIcon } from './VariantIcon';
+import { Icon } from '../Icon/Icon';
+import type { ButtonProps } from './ButtonTypes';
+
+export function useIcon(icon: ButtonProps['icon'], variant: ButtonProps['variant']) {
+  return useMemo(() => {
+    if (icon === 'default') {
+      return <VariantIcon variant={variant} />;
+    } else if (typeof icon === 'string') {
+      return <Icon icon={icon}></Icon>;
+    } else {
+      return icon;
+    }
+  }, [icon, variant]);
+}

--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -1,11 +1,10 @@
 import * as Icons from '@ubie/ubie-icons';
 import styles from './Icon.module.css';
 import { CustomDataAttributeProps } from '../../types/attributes';
+import { IconName } from '../../types/icon';
 import { TextColor } from '../../types/style';
 import { colorVariable } from '../../utils/style';
 import type { CSSProperties, FC } from 'react';
-
-type Icon = keyof typeof Icons;
 
 type IconSize = 'xs' | 'sm' | 'md' | 'lg' | 'xl' | '2xl' | '3xl' | '4xl';
 
@@ -38,7 +37,7 @@ type Props = {
   /**
    * アイコンの種類
    */
-  icon: Icon;
+  icon: IconName;
   /**
    * 色。指定しない場合はinheritとなり、親要素のcolorプロパティを継承します
    */

--- a/src/components/LinkCard/LinkCard.tsx
+++ b/src/components/LinkCard/LinkCard.tsx
@@ -5,7 +5,11 @@ import clsx from 'clsx';
 import { cloneElement, forwardRef, isValidElement } from 'react';
 import styles from './LinkCard.module.css';
 import { CustomDataAttributeProps } from '../../types/attributes';
+import { IconName } from '../../types/icon';
+import { Icon } from '../Icon/Icon';
 import type { ComponentType, ReactElement, ReactNode } from 'react';
+
+type IconProp = ComponentType | ReactElement | IconName;
 
 type Props = {
   /**
@@ -37,7 +41,7 @@ type Props = {
   /**
    * アイコン
    */
-  icon?: ComponentType | ReactElement;
+  icon?: IconProp;
 } & CustomDataAttributeProps;
 
 // ref https://github.com/microsoft/TypeScript/issues/53178
@@ -45,9 +49,13 @@ const _isValidElement = (el: ComponentType | ReactElement): el is ReactElement =
   return isValidElement(el);
 };
 
-const renderPropIcon = (icon: ComponentType | ReactElement) => {
+const renderPropIcon = (icon: IconProp) => {
   if (icon == null) {
     return null;
+  }
+
+  if (typeof icon === 'string') {
+    return <Icon icon={icon} />;
   }
 
   if (_isValidElement(icon)) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,3 +30,5 @@ export { Text } from './components/Text/Text';
 export { TextArea } from './components/TextArea/TextArea';
 export { Stack } from './components/Stack/Stack';
 export { Toggle } from './components/Toggle/Toggle';
+
+export type { IconName } from './types/icon';

--- a/src/stories/Button.stories.tsx
+++ b/src/stories/Button.stories.tsx
@@ -94,7 +94,7 @@ export const WithIcon: Story = {
       </Stack>
 
       <Stack spacing="lg" as="dl">
-        <dt style={{ fontWeight: 'bold' }}>Key specification</dt>
+        <dt style={{ fontWeight: 'bold' }}>Name specification</dt>
         <dd style={{ margin: 0 }}>
           <div style={{ display: 'flex', flexDirection: 'row', alignItems: 'flex-start', gap: '32px' }}>
             <Button icon="BlankLinkIcon" {...defaultArgs}>

--- a/src/stories/Button.stories.tsx
+++ b/src/stories/Button.stories.tsx
@@ -92,6 +92,40 @@ export const WithIcon: Story = {
           </div>
         </dd>
       </Stack>
+
+      <Stack spacing="lg" as="dl">
+        <dt style={{ fontWeight: 'bold' }}>Key specification</dt>
+        <dd style={{ margin: 0 }}>
+          <div style={{ display: 'flex', flexDirection: 'row', alignItems: 'flex-start', gap: '32px' }}>
+            <Button icon="BlankLinkIcon" {...defaultArgs}>
+              Icon
+            </Button>
+            <Button suffixIcon="BlankLinkIcon" {...defaultArgs}>
+              Suffix Icon
+            </Button>
+            <Button fixedIcon="BlankLinkIcon" {...defaultArgs}>
+              Fixed Icon
+            </Button>
+          </div>
+        </dd>
+      </Stack>
+
+      <Stack spacing="lg" as="dl">
+        <dt style={{ fontWeight: 'bold' }}>Auth Icon</dt>
+        <dd style={{ margin: 0 }}>
+          <div style={{ display: 'flex', flexDirection: 'row', alignItems: 'flex-start', gap: '32px' }}>
+            <Button variant="authGoogle" icon="default" {...defaultArgs}>
+              Icon
+            </Button>
+            <Button variant="authGoogle" suffixIcon="default" {...defaultArgs}>
+              Suffix Icon
+            </Button>
+            <Button variant="authGoogle" fixedIcon="default" {...defaultArgs}>
+              Fixed Icon
+            </Button>
+          </div>
+        </dd>
+      </Stack>
     </Stack>
   ),
   args: defaultArgs,

--- a/src/stories/LinkButton.stories.tsx
+++ b/src/stories/LinkButton.stories.tsx
@@ -96,6 +96,40 @@ export const WithIcon: Story = {
           </div>
         </dd>
       </Stack>
+
+      <Stack spacing="lg" as="dl">
+        <dt style={{ fontWeight: 'bold' }}>Key specification</dt>
+        <dd style={{ margin: 0 }}>
+          <div style={{ display: 'flex', flexDirection: 'row', alignItems: 'flex-start', gap: '32px' }}>
+            <LinkButton icon="BlankLinkIcon" {...defaultArgs}>
+              Icon
+            </LinkButton>
+            <LinkButton suffixIcon="BlankLinkIcon" {...defaultArgs}>
+              Suffix Icon
+            </LinkButton>
+            <LinkButton fixedIcon="BlankLinkIcon" {...defaultArgs}>
+              Fixed Icon
+            </LinkButton>
+          </div>
+        </dd>
+      </Stack>
+
+      <Stack spacing="lg" as="dl">
+        <dt style={{ fontWeight: 'bold' }}>Auth Icon</dt>
+        <dd style={{ margin: 0 }}>
+          <div style={{ display: 'flex', flexDirection: 'row', alignItems: 'flex-start', gap: '32px' }}>
+            <LinkButton variant="authGoogle" icon="default" {...defaultArgs}>
+              Icon
+            </LinkButton>
+            <LinkButton variant="authGoogle" suffixIcon="default" {...defaultArgs}>
+              Suffix Icon
+            </LinkButton>
+            <LinkButton variant="authGoogle" fixedIcon="default" {...defaultArgs}>
+              Fixed Icon
+            </LinkButton>
+          </div>
+        </dd>
+      </Stack>
     </Stack>
   ),
 };

--- a/src/stories/LinkButton.stories.tsx
+++ b/src/stories/LinkButton.stories.tsx
@@ -98,7 +98,7 @@ export const WithIcon: Story = {
       </Stack>
 
       <Stack spacing="lg" as="dl">
-        <dt style={{ fontWeight: 'bold' }}>Key specification</dt>
+        <dt style={{ fontWeight: 'bold' }}>Name specification</dt>
         <dd style={{ margin: 0 }}>
           <div style={{ display: 'flex', flexDirection: 'row', alignItems: 'flex-start', gap: '32px' }}>
             <LinkButton icon="BlankLinkIcon" {...defaultArgs}>

--- a/src/stories/LinkCard.stories.tsx
+++ b/src/stories/LinkCard.stories.tsx
@@ -67,3 +67,14 @@ export const CustomDataAttribute: Story = {
     'data-test-id': 'link-card-custom-attribute',
   },
 };
+
+export const VariousWaysToSpecifyIcon: Story = {
+  render: (args) => (
+    <Stack spacing="md">
+      <LinkCard {...args} href="https://vitals.ubie.life/" icon="HospitalIcon" title="Icon Name" />
+      <LinkCard {...args} href="https://vitals.ubie.life/" icon={<HospitalIcon />} title="RectElement" />
+      <LinkCard {...args} href="https://vitals.ubie.life/" icon={HospitalIcon} title="ComponentType" />
+    </Stack>
+  ),
+  args: defaultArgs,
+};

--- a/src/types/icon.ts
+++ b/src/types/icon.ts
@@ -1,0 +1,3 @@
+import * as Icons from '@ubie/ubie-icons';
+
+export type IconName = keyof typeof Icons;


### PR DESCRIPTION
# Changes

- allow icon prop to be specified by name
- Button / LinkButton / LinkCard

## Button
<img width="1106" alt="スクリーンショット 2024-11-01 14 04 04" src="https://github.com/user-attachments/assets/62768c55-e270-4494-8d2f-566d12f7b8af">

## LinkButton
<img width="1179" alt="スクリーンショット 2024-11-01 14 04 11" src="https://github.com/user-attachments/assets/6afa47be-07cc-4052-8e11-3e0b623d8317">

## LinkCard

<img width="635" alt="スクリーンショット 2024-11-01 14 05 39" src="https://github.com/user-attachments/assets/e0451580-ed98-462f-be01-900eebd877c5">


# Check

No change in rendering results

- [-] Browser verification (minimum) Android Chrome/iOS Safari(375px-)
- [-] CSS not affected by inheritance
- [-] Layout does not break even if there is an overflow
- [-] Layout does not break when wraps
- [-] Added new Component
  - [ ] Added data-* prop and id prop
- [-] Updated [Ubie Vitals](https://github.com/ubie-oss/ubie-vitals-website) or Added an update [issue](https://github.com/ubie-oss/ubie-vitals-website/issues)(if needed)

