### PR TITLE
Unify Icon component size specification with other components

### DIFF
--- a/src/components/Icon/Icon.stories.tsx
+++ b/src/components/Icon/Icon.stories.tsx
@@ -26,6 +26,19 @@ export const Size: Story = {
         <Icon {...args} size="md" />
         <Icon {...args} size="lg" />
         <Icon {...args} size="xl" />
+        <Icon {...args} size="xxl" />
+        <Icon {...args} size="xxxl" />
+        <Icon {...args} size="xxxxl" />
+      </Flex>
+    </>
+  ),
+  args: defaultArgs,
+};
+
+export const SizeAlias: Story = {
+  render: (args) => (
+    <>
+      <Flex alignItems="center" spacing="sm">
         <Icon {...args} size="2xl" />
         <Icon {...args} size="3xl" />
         <Icon {...args} size="4xl" />

--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -7,7 +7,9 @@ import type { CSSProperties, FC } from 'react';
 
 type Icon = keyof typeof Icons;
 
-type IconSize = 'xs' | 'sm' | 'md' | 'lg' | 'xl' | '2xl' | '3xl' | '4xl';
+type IconSize = 'xs' | 'sm' | 'md' | 'lg' | 'xl' | 'xxl' | 'xxxl' | 'xxxxl';
+type IconSizeAlias = '2xl' | '3xl' | '4xl';
+type SizeProp = IconSize | IconSizeAlias;
 
 const toIconSizeEmValue = (size: IconSize): string => {
   switch (size) {
@@ -21,16 +23,29 @@ const toIconSizeEmValue = (size: IconSize): string => {
       return '1.75rem';
     case 'xl':
       return '2rem';
-    case '2xl':
+    case 'xxl':
       return '4rem';
-    case '3xl':
+    case 'xxxl':
       return '5rem';
-    case '4xl':
+    case 'xxxxl':
       return '6.5rem';
     default:
       // eslint-disable-next-line no-case-declarations
       const _: never = size;
       throw new Error(`Unknown size: ${_}`);
+  }
+};
+
+const normalizeSize = (icon: IconSize | IconSizeAlias): IconSize => {
+  switch (icon) {
+    case '2xl':
+      return 'xxl';
+    case '3xl':
+      return 'xxxl';
+    case '4xl':
+      return 'xxxxl';
+    default:
+      return icon;
   }
 };
 
@@ -45,10 +60,11 @@ type Props = {
   color?: TextColor;
   /**
    * サイズ
-   * xs=16px, sm=20px, md=24px, lg=28px, xl=32px, 2xl=64px, 3xl=80px, 4xl=104px
+   * xs=16px, sm=20px, md=24px, lg=28px, xl=32px, xxl=64px, xxxl=80px, xxxxl=104px
+   * 2xl、3xl、4xlはdeprecatedな指定となります
    * @default md
    */
-  size?: IconSize;
+  size?: SizeProp;
   /**
    * ネイティブの`id`属性。ページで固有のIDを指定
    */
@@ -65,7 +81,7 @@ type Props = {
  */
 export const Icon: FC<Props> = ({ icon, color, size = 'md', label, ...otherProps }) => {
   const IconComponent = Icons[icon];
-  const _sizeValue = toIconSizeEmValue(size);
+  const _sizeValue = toIconSizeEmValue(normalizeSize(size));
   return (
     <IconComponent
       role="img"


### PR DESCRIPTION
Retain the existing specification as an alias.

# Changes

- added expressions such as xxxl to size specification
- added comment to specify methods such as 2xl not to be used in the future.

## Screenshot

<img width="507" alt="スクリーンショット 2024-11-01 15 20 19" src="https://github.com/user-attachments/assets/13e264dc-daf2-49f7-a778-b1a3afb7ccb3">

alias specification:

<img width="333" alt="スクリーンショット 2024-11-01 15 20 26" src="https://github.com/user-attachments/assets/44f155c5-72cb-498a-a180-4b9f013e001f">

# Check

No change in rendering results

- [-] Browser verification (minimum) Android Chrome/iOS Safari(375px-)
- [-] CSS not affected by inheritance
- [-] Layout does not break even if there is an overflow
- [-] Layout does not break when wraps
- [-] Added new Component
  - [ ] Added data-* prop and id prop
- [-] Updated [Ubie Vitals](https://github.com/ubie-oss/ubie-vitals-website) or Added an update [issue](https://github.com/ubie-oss/ubie-vitals-website/issues)(if needed)

