### PR TITLE
Add prefixIcon prop to Button components(icon alias)

### DIFF
--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -3,7 +3,7 @@
 import { clsx } from 'clsx';
 import { type CSSProperties, forwardRef } from 'react';
 import styles from './Button.module.css';
-import { VariantIcon } from './VariantIcon';
+import { useIcon } from './useIcon';
 import { marginVariables } from '../../utils/style';
 import type { ButtonProps } from './ButtonTypes';
 
@@ -34,9 +34,9 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
     },
     ref,
   ) => {
-    const icon = _icon === 'default' ? <VariantIcon variant={variant} /> : _icon;
-    const fixedIcon = _fixedIcon === 'default' ? <VariantIcon variant={variant} /> : _fixedIcon;
-    const suffixIcon = _suffixIcon === 'default' ? <VariantIcon variant={variant} /> : _suffixIcon;
+    const icon = useIcon(_icon, variant);
+    const fixedIcon = useIcon(_fixedIcon, variant);
+    const suffixIcon = useIcon(_suffixIcon, variant);
     const cls = clsx({
       [styles.button]: true,
       [styles[variant]]: true,

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -14,7 +14,8 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
       variant = 'primary',
       size = 'large',
       block = false,
-      icon: _icon,
+      icon,
+      prefixIcon: _prefixIcon,
       fixedIcon: _fixedIcon,
       suffixIcon: _suffixIcon,
       type = 'button',
@@ -34,7 +35,7 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
     },
     ref,
   ) => {
-    const icon = useIcon(_icon, variant);
+    const prefixIcon = useIcon(icon || _prefixIcon, variant);
     const fixedIcon = useIcon(_fixedIcon, variant);
     const suffixIcon = useIcon(_suffixIcon, variant);
     const cls = clsx({
@@ -82,7 +83,7 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
         {loading && <span className={styles.loadingLabel}>{loadingLabel}</span>}
         {fixedIcon && <span className={styles.fixedIcon}>{fixedIcon}</span>}
         <span className={styles.label}>
-          {icon && <span className={clsx(styles.icon, loading && styles.loading)}>{icon}</span>}
+          {prefixIcon && <span className={clsx(styles.icon, loading && styles.loading)}>{prefixIcon}</span>}
           <span className={clsx(styles.children, loading && styles.loading)}>{children}</span>
           {suffixIcon && <span className={styles.suffixIcon}>{suffixIcon}</span>}
         </span>

--- a/src/components/Button/ButtonTypes.ts
+++ b/src/components/Button/ButtonTypes.ts
@@ -33,11 +33,7 @@ export type BaseProps = {
    */
   block?: boolean;
   /**
-   * アイコン
-   */
-  icon?: 'default' | ReactElement | IconName;
-  /**
-   * Fixedアイコン
+   * Fixedアイコンa
    */
   fixedIcon?: 'default' | ReactElement | IconName;
   /**
@@ -48,7 +44,27 @@ export type BaseProps = {
    * ラベルの折り返しを指定
    */
   whiteSpace?: 'normal' | 'nowrap' | 'pre' | 'pre-wrap' | 'pre-line' | 'break-spaces';
-} & MarginProps &
+} & (
+  | {
+      /**
+       * アイコン
+       */
+      icon?: 'default' | ReactElement | IconName;
+      prefixIcon?: never;
+    }
+  | {
+      /**
+       * アイコン
+       */
+      prefixIcon?: 'default' | ReactElement | IconName;
+      icon?: never;
+    }
+  | {
+      icon?: never;
+      prefixIcon?: never;
+    }
+) &
+  MarginProps &
   CustomDataAttributeProps;
 
 export type OnlyButtonProps = {

--- a/src/components/Button/ButtonTypes.ts
+++ b/src/components/Button/ButtonTypes.ts
@@ -1,4 +1,5 @@
 import { CustomDataAttributeProps } from '../../types/attributes';
+import { IconName } from '../../types/icon';
 import type { MarginProps } from '../../types/style';
 import type { AnchorHTMLAttributes, ButtonHTMLAttributes, ReactElement, ReactNode } from 'react';
 
@@ -34,15 +35,15 @@ export type BaseProps = {
   /**
    * アイコン
    */
-  icon?: 'default' | ReactNode;
+  icon?: 'default' | ReactElement | IconName;
   /**
    * Fixedアイコン
    */
-  fixedIcon?: 'default' | ReactNode;
+  fixedIcon?: 'default' | ReactElement | IconName;
   /**
    * 後方配置のアイコン
    */
-  suffixIcon?: 'default' | ReactNode;
+  suffixIcon?: 'default' | ReactElement | IconName;
   /**
    * ラベルの折り返しを指定
    */

--- a/src/components/Button/LinkButton.tsx
+++ b/src/components/Button/LinkButton.tsx
@@ -16,7 +16,8 @@ export const LinkButton = forwardRef<HTMLAnchorElement, LinkButtonProps>(
       variant = 'primary',
       size = 'large',
       block = false,
-      icon: _icon,
+      icon,
+      prefixIcon: _prefixIcon,
       fixedIcon: _fixedIcon,
       suffixIcon: _suffixIcon,
       whiteSpace = 'normal',
@@ -31,7 +32,7 @@ export const LinkButton = forwardRef<HTMLAnchorElement, LinkButtonProps>(
     },
     forwardedRef,
   ) => {
-    const icon = useIcon(_icon, variant);
+    const prefixIcon = useIcon(icon || _prefixIcon, variant);
     const fixedIcon = useIcon(_fixedIcon, variant);
     const suffixIcon = useIcon(_suffixIcon, variant);
     const cls = clsx({
@@ -67,7 +68,7 @@ export const LinkButton = forwardRef<HTMLAnchorElement, LinkButtonProps>(
       <>
         {fixedIcon && <span className={styles.fixedIcon}>{fixedIcon}</span>}
         <span className={styles.label}>
-          {icon && <span className={styles.icon}>{icon}</span>}
+          {prefixIcon && <span className={styles.icon}>{prefixIcon}</span>}
           {children}
           {suffixIcon && <span className={styles.suffixIcon}>{suffixIcon}</span>}
         </span>

--- a/src/components/Button/LinkButton.tsx
+++ b/src/components/Button/LinkButton.tsx
@@ -3,7 +3,7 @@
 import clsx from 'clsx';
 import { cloneElement, CSSProperties, forwardRef } from 'react';
 import styles from './Button.module.css';
-import { VariantIcon } from './VariantIcon';
+import { useIcon } from './useIcon';
 import { marginVariables } from '../../utils/style';
 import type { LinkButtonProps } from './ButtonTypes';
 import type { ReactNode } from 'react';
@@ -31,9 +31,9 @@ export const LinkButton = forwardRef<HTMLAnchorElement, LinkButtonProps>(
     },
     forwardedRef,
   ) => {
-    const icon = _icon === 'default' ? <VariantIcon variant={variant} /> : _icon;
-    const fixedIcon = _fixedIcon === 'default' ? <VariantIcon variant={variant} /> : _fixedIcon;
-    const suffixIcon = _suffixIcon === 'default' ? <VariantIcon variant={variant} /> : _suffixIcon;
+    const icon = useIcon(_icon, variant);
+    const fixedIcon = useIcon(_fixedIcon, variant);
+    const suffixIcon = useIcon(_suffixIcon, variant);
     const cls = clsx({
       [styles.button]: true,
       [styles[variant]]: true,

--- a/src/components/Button/useIcon.tsx
+++ b/src/components/Button/useIcon.tsx
@@ -1,0 +1,16 @@
+import { useMemo } from 'react';
+import { VariantIcon } from './VariantIcon';
+import { Icon } from '../Icon/Icon';
+import type { ButtonProps } from './ButtonTypes';
+
+export function useIcon(icon: ButtonProps['icon'], variant: ButtonProps['variant']) {
+  return useMemo(() => {
+    if (icon === 'default') {
+      return <VariantIcon variant={variant} />;
+    } else if (typeof icon === 'string') {
+      return <Icon icon={icon}></Icon>;
+    } else {
+      return icon;
+    }
+  }, [icon, variant]);
+}

--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -1,11 +1,10 @@
 import * as Icons from '@ubie/ubie-icons';
 import styles from './Icon.module.css';
 import { CustomDataAttributeProps } from '../../types/attributes';
+import { IconName } from '../../types/icon';
 import { TextColor } from '../../types/style';
 import { colorVariable } from '../../utils/style';
 import type { CSSProperties, FC } from 'react';
-
-type Icon = keyof typeof Icons;
 
 type IconSize = 'xs' | 'sm' | 'md' | 'lg' | 'xl' | '2xl' | '3xl' | '4xl';
 
@@ -38,7 +37,7 @@ type Props = {
   /**
    * アイコンの種類
    */
-  icon: Icon;
+  icon: IconName;
   /**
    * 色。指定しない場合はinheritとなり、親要素のcolorプロパティを継承します
    */

--- a/src/components/LinkCard/LinkCard.tsx
+++ b/src/components/LinkCard/LinkCard.tsx
@@ -5,7 +5,11 @@ import clsx from 'clsx';
 import { cloneElement, forwardRef, isValidElement } from 'react';
 import styles from './LinkCard.module.css';
 import { CustomDataAttributeProps } from '../../types/attributes';
+import { IconName } from '../../types/icon';
+import { Icon } from '../Icon/Icon';
 import type { ComponentType, ReactElement, ReactNode } from 'react';
+
+type IconProp = ComponentType | ReactElement | IconName;
 
 type Props = {
   /**
@@ -37,7 +41,7 @@ type Props = {
   /**
    * アイコン
    */
-  icon?: ComponentType | ReactElement;
+  icon?: IconProp;
 } & CustomDataAttributeProps;
 
 // ref https://github.com/microsoft/TypeScript/issues/53178
@@ -45,9 +49,13 @@ const _isValidElement = (el: ComponentType | ReactElement): el is ReactElement =
   return isValidElement(el);
 };
 
-const renderPropIcon = (icon: ComponentType | ReactElement) => {
+const renderPropIcon = (icon: IconProp) => {
   if (icon == null) {
     return null;
+  }
+
+  if (typeof icon === 'string') {
+    return <Icon icon={icon} />;
   }
 
   if (_isValidElement(icon)) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,3 +30,5 @@ export { Text } from './components/Text/Text';
 export { TextArea } from './components/TextArea/TextArea';
 export { Stack } from './components/Stack/Stack';
 export { Toggle } from './components/Toggle/Toggle';
+
+export type { IconName } from './types/icon';

--- a/src/stories/Button.stories.tsx
+++ b/src/stories/Button.stories.tsx
@@ -52,15 +52,15 @@ export const WithIcon: Story = {
   render: () => (
     <Stack spacing="lg">
       <Stack spacing="lg" as="dl">
-        <dt style={{ fontWeight: 'bold' }}>Default Position</dt>
+        <dt style={{ fontWeight: 'bold' }}>Position Prefix</dt>
         <dd style={{ margin: 0 }}>
           <div style={{ display: 'flex', flexDirection: 'row', alignItems: 'flex-start', gap: '32px' }}>
-            <Button icon={<Icon icon="UbieIcon" />} {...defaultArgs} />
-            <Button icon={<Icon icon="UbieIcon" />} {...defaultArgs} variant="secondary" />
-            <Button icon={<Icon icon="UbieIcon" />} {...defaultArgs} variant="accent" />
-            <Button icon={<Icon icon="UbieIcon" />} {...defaultArgs} variant="alert" />
-            <Button icon={<Icon icon="UbieIcon" />} {...defaultArgs} variant="text" />
-            <Button icon={<Icon icon="TrashIcon" />} {...defaultArgs} variant="textAlert" />
+            <Button prefixIcon={<Icon icon="UbieIcon" />} {...defaultArgs} />
+            <Button prefixIcon={<Icon icon="UbieIcon" />} {...defaultArgs} variant="secondary" />
+            <Button prefixIcon={<Icon icon="UbieIcon" />} {...defaultArgs} variant="accent" />
+            <Button prefixIcon={<Icon icon="UbieIcon" />} {...defaultArgs} variant="alert" />
+            <Button prefixIcon={<Icon icon="UbieIcon" />} {...defaultArgs} variant="text" />
+            <Button prefixIcon={<Icon icon="TrashIcon" />} {...defaultArgs} variant="textAlert" />
           </div>
         </dd>
       </Stack>
@@ -126,6 +126,20 @@ export const WithIcon: Story = {
           </div>
         </dd>
       </Stack>
+
+      <Stack spacing="lg" as="dl">
+        <dt style={{ fontWeight: 'bold' }}>icon prop(deprecated)</dt>
+        <dd style={{ margin: 0 }}>
+          <div style={{ display: 'flex', flexDirection: 'row', alignItems: 'flex-start', gap: '32px' }}>
+            <Button icon={<Icon icon="UbieIcon" />} {...defaultArgs} />
+            <Button icon={<Icon icon="UbieIcon" />} {...defaultArgs} variant="secondary" />
+            <Button icon={<Icon icon="UbieIcon" />} {...defaultArgs} variant="accent" />
+            <Button icon={<Icon icon="UbieIcon" />} {...defaultArgs} variant="alert" />
+            <Button icon={<Icon icon="UbieIcon" />} {...defaultArgs} variant="text" />
+            <Button icon={<Icon icon="TrashIcon" />} {...defaultArgs} variant="textAlert" />
+          </div>
+        </dd>
+      </Stack>
     </Stack>
   ),
   args: defaultArgs,
@@ -154,7 +168,7 @@ export const Block: Story = {
 export const Disabled: Story = {
   render: () => (
     <div style={{ display: 'flex', flexDirection: 'row', alignItems: 'flex-start', gap: '32px' }}>
-      <Button {...defaultArgs} disabled />
+      <Button {...defaultArgs} prefixIcon="UbieIcon" disabled />
       <Button {...defaultArgs} variant="secondary" disabled />
       <Button {...defaultArgs} variant="accent" disabled />
       <Button {...defaultArgs} variant="alert" disabled />
@@ -201,7 +215,7 @@ export const Loading: Story = {
       </div>
 
       <div style={{ display: 'flex', flexDirection: 'row', alignItems: 'flex-start', gap: '32px' }}>
-        <Button {...args} icon={<Icon icon="UbieIcon" />} size="medium" loadingLabel="ラベル変更">
+        <Button icon={<Icon icon="UbieIcon" />} size="medium" loading loadingLabel="ラベル変更">
           次のページへ
         </Button>
         <Button {...args} variant="secondary" size="medium" disabled />

--- a/src/stories/Button.stories.tsx
+++ b/src/stories/Button.stories.tsx
@@ -94,7 +94,7 @@ export const WithIcon: Story = {
       </Stack>
 
       <Stack spacing="lg" as="dl">
-        <dt style={{ fontWeight: 'bold' }}>Key specification</dt>
+        <dt style={{ fontWeight: 'bold' }}>Name specification</dt>
         <dd style={{ margin: 0 }}>
           <div style={{ display: 'flex', flexDirection: 'row', alignItems: 'flex-start', gap: '32px' }}>
             <Button icon="BlankLinkIcon" {...defaultArgs}>

--- a/src/stories/Button.stories.tsx
+++ b/src/stories/Button.stories.tsx
@@ -92,6 +92,40 @@ export const WithIcon: Story = {
           </div>
         </dd>
       </Stack>
+
+      <Stack spacing="lg" as="dl">
+        <dt style={{ fontWeight: 'bold' }}>Key specification</dt>
+        <dd style={{ margin: 0 }}>
+          <div style={{ display: 'flex', flexDirection: 'row', alignItems: 'flex-start', gap: '32px' }}>
+            <Button icon="BlankLinkIcon" {...defaultArgs}>
+              Icon
+            </Button>
+            <Button suffixIcon="BlankLinkIcon" {...defaultArgs}>
+              Suffix Icon
+            </Button>
+            <Button fixedIcon="BlankLinkIcon" {...defaultArgs}>
+              Fixed Icon
+            </Button>
+          </div>
+        </dd>
+      </Stack>
+
+      <Stack spacing="lg" as="dl">
+        <dt style={{ fontWeight: 'bold' }}>Auth Icon</dt>
+        <dd style={{ margin: 0 }}>
+          <div style={{ display: 'flex', flexDirection: 'row', alignItems: 'flex-start', gap: '32px' }}>
+            <Button variant="authGoogle" icon="default" {...defaultArgs}>
+              Icon
+            </Button>
+            <Button variant="authGoogle" suffixIcon="default" {...defaultArgs}>
+              Suffix Icon
+            </Button>
+            <Button variant="authGoogle" fixedIcon="default" {...defaultArgs}>
+              Fixed Icon
+            </Button>
+          </div>
+        </dd>
+      </Stack>
     </Stack>
   ),
   args: defaultArgs,

--- a/src/stories/LinkButton.stories.tsx
+++ b/src/stories/LinkButton.stories.tsx
@@ -96,6 +96,40 @@ export const WithIcon: Story = {
           </div>
         </dd>
       </Stack>
+
+      <Stack spacing="lg" as="dl">
+        <dt style={{ fontWeight: 'bold' }}>Key specification</dt>
+        <dd style={{ margin: 0 }}>
+          <div style={{ display: 'flex', flexDirection: 'row', alignItems: 'flex-start', gap: '32px' }}>
+            <LinkButton icon="BlankLinkIcon" {...defaultArgs}>
+              Icon
+            </LinkButton>
+            <LinkButton suffixIcon="BlankLinkIcon" {...defaultArgs}>
+              Suffix Icon
+            </LinkButton>
+            <LinkButton fixedIcon="BlankLinkIcon" {...defaultArgs}>
+              Fixed Icon
+            </LinkButton>
+          </div>
+        </dd>
+      </Stack>
+
+      <Stack spacing="lg" as="dl">
+        <dt style={{ fontWeight: 'bold' }}>Auth Icon</dt>
+        <dd style={{ margin: 0 }}>
+          <div style={{ display: 'flex', flexDirection: 'row', alignItems: 'flex-start', gap: '32px' }}>
+            <LinkButton variant="authGoogle" icon="default" {...defaultArgs}>
+              Icon
+            </LinkButton>
+            <LinkButton variant="authGoogle" suffixIcon="default" {...defaultArgs}>
+              Suffix Icon
+            </LinkButton>
+            <LinkButton variant="authGoogle" fixedIcon="default" {...defaultArgs}>
+              Fixed Icon
+            </LinkButton>
+          </div>
+        </dd>
+      </Stack>
     </Stack>
   ),
 };

--- a/src/stories/LinkButton.stories.tsx
+++ b/src/stories/LinkButton.stories.tsx
@@ -98,7 +98,7 @@ export const WithIcon: Story = {
       </Stack>
 
       <Stack spacing="lg" as="dl">
-        <dt style={{ fontWeight: 'bold' }}>Key specification</dt>
+        <dt style={{ fontWeight: 'bold' }}>Name specification</dt>
         <dd style={{ margin: 0 }}>
           <div style={{ display: 'flex', flexDirection: 'row', alignItems: 'flex-start', gap: '32px' }}>
             <LinkButton icon="BlankLinkIcon" {...defaultArgs}>

--- a/src/stories/LinkButton.stories.tsx
+++ b/src/stories/LinkButton.stories.tsx
@@ -53,16 +53,16 @@ export const WithIcon: Story = {
   render: () => (
     <Stack spacing="lg">
       <Stack spacing="lg" as="dl">
-        <dt style={{ fontWeight: 'bold' }}>Default Position</dt>
+        <dt style={{ fontWeight: 'bold' }}>Position Prefix</dt>
 
         <dd style={{ margin: 0 }}>
           <div style={{ display: 'flex', flexDirection: 'row', alignItems: 'flex-start', gap: '32px' }}>
-            <LinkButton icon={<UbieIcon />} {...defaultArgs} />
-            <LinkButton icon={<UbieIcon />} {...defaultArgs} variant="secondary" />
-            <LinkButton icon={<UbieIcon />} {...defaultArgs} variant="accent" />
-            <LinkButton icon={<UbieIcon />} {...defaultArgs} variant="alert" />
-            <LinkButton icon={<UbieIcon />} {...defaultArgs} variant="text" />
-            <LinkButton icon={<TrashIcon />} {...defaultArgs} variant="textAlert" />
+            <LinkButton prefixIcon={<UbieIcon />} {...defaultArgs} />
+            <LinkButton prefixIcon={<UbieIcon />} {...defaultArgs} variant="secondary" />
+            <LinkButton prefixIcon={<UbieIcon />} {...defaultArgs} variant="accent" />
+            <LinkButton prefixIcon={<UbieIcon />} {...defaultArgs} variant="alert" />
+            <LinkButton prefixIcon={<UbieIcon />} {...defaultArgs} variant="text" />
+            <LinkButton prefixIcon={<TrashIcon />} {...defaultArgs} variant="textAlert" />
           </div>
         </dd>
       </Stack>
@@ -127,6 +127,21 @@ export const WithIcon: Story = {
             <LinkButton variant="authGoogle" fixedIcon="default" {...defaultArgs}>
               Fixed Icon
             </LinkButton>
+          </div>
+        </dd>
+      </Stack>
+
+      <Stack spacing="lg" as="dl">
+        <dt style={{ fontWeight: 'bold' }}>icon prop(deprecated)</dt>
+
+        <dd style={{ margin: 0 }}>
+          <div style={{ display: 'flex', flexDirection: 'row', alignItems: 'flex-start', gap: '32px' }}>
+            <LinkButton icon={<UbieIcon />} {...defaultArgs} />
+            <LinkButton icon={<UbieIcon />} {...defaultArgs} variant="secondary" />
+            <LinkButton icon={<UbieIcon />} {...defaultArgs} variant="accent" />
+            <LinkButton icon={<UbieIcon />} {...defaultArgs} variant="alert" />
+            <LinkButton icon={<UbieIcon />} {...defaultArgs} variant="text" />
+            <LinkButton icon={<TrashIcon />} {...defaultArgs} variant="textAlert" />
           </div>
         </dd>
       </Stack>

--- a/src/stories/LinkCard.stories.tsx
+++ b/src/stories/LinkCard.stories.tsx
@@ -67,3 +67,14 @@ export const CustomDataAttribute: Story = {
     'data-test-id': 'link-card-custom-attribute',
   },
 };
+
+export const VariousWaysToSpecifyIcon: Story = {
+  render: (args) => (
+    <Stack spacing="md">
+      <LinkCard {...args} href="https://vitals.ubie.life/" icon="HospitalIcon" title="Icon Name" />
+      <LinkCard {...args} href="https://vitals.ubie.life/" icon={<HospitalIcon />} title="RectElement" />
+      <LinkCard {...args} href="https://vitals.ubie.life/" icon={HospitalIcon} title="ComponentType" />
+    </Stack>
+  ),
+  args: defaultArgs,
+};

--- a/src/types/icon.ts
+++ b/src/types/icon.ts
@@ -1,0 +1,3 @@
+import * as Icons from '@ubie/ubie-icons';
+
+export type IconName = keyof typeof Icons;


### PR DESCRIPTION
# Changes

blocked by https://github.com/ubie-oss/ubie-ui/pull/139

- add prefixIcon prop to Button components
  - It is clearer to use “prefix” rather than simply “icon”.
  - unify naming with suffixIcon
- prefixIcon is icon alias
  - I want to delete the icon prop, but it will take a lot of time, so I'll add an alias for now.

## Screenshots

Button:
<img width="1469" alt="スクリーンショット 2024-11-01 21 55 48" src="https://github.com/user-attachments/assets/722fc6bc-3784-4661-920a-c52354bfaf49">

LinkButton:
<img width="1421" alt="スクリーンショット 2024-11-01 21 56 20" src="https://github.com/user-attachments/assets/e1c8b381-6461-4620-8c48-4b7dac0699c7">

# Check

No change to the rendering result

- [-] Browser verification (minimum) Android Chrome/iOS Safari(375px-)
- [-] CSS not affected by inheritance
- [-] Layout does not break even if there is an overflow
- [-] Layout does not break when wraps
- [-] Added new Component
  - [ ] Added data-* prop and id prop
- [-] Updated [Ubie Vitals](https://github.com/ubie-oss/ubie-vitals-website) or Added an update [issue](https://github.com/ubie-oss/ubie-vitals-website/issues)(if needed)

