### PR TITLE
Add gap alias prop to Stack Component 

### DIFF
--- a/src/components/Flex/Flex.tsx
+++ b/src/components/Flex/Flex.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import clsx from 'clsx';
-import { isValidElement, cloneElement } from 'react';
+import { isValidElement, cloneElement, useMemo } from 'react';
 import styles from './Flex.module.css';
 import { CustomDataAttributeProps } from '../../types/attributes'; // 追加したインポート
 import { Spacing, AlignItems, JustifyContent, FlexDirection, WidthProps } from '../../types/style';
@@ -19,11 +19,6 @@ type Props = {
    * @default div
    */
   as?: HTMLTagname | ReactElement<ComponentType<typeof Box>>;
-  /**
-   * 子要素同士の間隔。指定しない場合は0
-   * xxs=4px, xs=8px, sm=12px, md=16px, lg=24px, xl=40px, xxl=64px
-   */
-  spacing?: Spacing;
   /**
    * direction 重ねる向き
    * @default row
@@ -58,7 +53,29 @@ type Props = {
    * @default false
    */
   inline?: boolean;
-} & MarginProps &
+} & (
+  | {
+      /**
+       * 子要素の間隔。指定しない場合は0
+       * xxs=4px, xs=8px, sm=12px, md=16px, lg=24px, xl=40px, xxl=64px
+       */
+      spacing: Spacing;
+      gap?: never;
+    }
+  | {
+      /**
+       * spacingのエイリアス（どちらかしか指定できません）
+       * xxs=4px, xs=8px, sm=12px, md=16px, lg=24px, xl=40px, xxl=64px
+       */
+      gap: Spacing;
+      spacing?: never;
+    }
+  | {
+      gap?: never;
+      spacing?: never;
+    }
+) &
+  MarginProps &
   PaddingProps &
   Omit<WidthProps, 'width'> &
   CustomDataAttributeProps;
@@ -71,6 +88,7 @@ export const Flex: FC<PropsWithChildren<Props>> = ({
   justifyContent = 'flex-start',
   wrap,
   spacing,
+  gap,
   height,
   inline,
   p,
@@ -102,6 +120,15 @@ export const Flex: FC<PropsWithChildren<Props>> = ({
   };
 
   const width = _width === 'full' ? '100%' : _width;
+  const _spacing = useMemo(() => {
+    if (gap != null) {
+      return gap;
+    } else if (spacing != null) {
+      return spacing;
+    } else {
+      return undefined;
+    }
+  }, [gap, spacing]);
 
   return createElement(
     {
@@ -111,7 +138,7 @@ export const Flex: FC<PropsWithChildren<Props>> = ({
         '--align-items': alignItems,
         '--justify-content': justifyContent,
         '--flex-wrap': wrap ? 'wrap' : 'nowrap',
-        ...gapVariables(spacing),
+        ...gapVariables(_spacing),
         ...paddingVariables({
           p,
           px,

--- a/src/stories/Flex.stories.tsx
+++ b/src/stories/Flex.stories.tsx
@@ -61,6 +61,16 @@ export const Spacing: Story = {
   ),
 };
 
+export const Gap: Story = {
+  render: () => (
+    <Flex gap="xl">
+      <div>xxl</div>
+      <div>xxl</div>
+      <div>xxl</div>
+    </Flex>
+  ),
+};
+
 export const Vertical: Story = {
   render: () => (
     <div>

--- a/src/stories/Stack.stories.tsx
+++ b/src/stories/Stack.stories.tsx
@@ -143,7 +143,7 @@ export const Width: Story = {
 
 export const Gap: Story = {
   render: () => (
-    <Stack spacing="md">
+    <Stack gap="md">
       <p style={{ margin: 0 }}>Text</p>
       <p style={{ margin: 0 }}>Text</p>
       <p style={{ margin: 0 }}>Text</p>


### PR DESCRIPTION
# Changes

add gap prop
an alias for spacing prop
only one of the two props can be specified

<img width="553" alt="スクリーンショット 2024-11-15 17 05 59" src="https://github.com/user-attachments/assets/a21c3063-6d8f-4552-88f6-9015e651a548">


# Check

- [-] Browser verification (minimum) Android Chrome/iOS Safari(375px-)
- [-] CSS not affected by inheritance
- [-] Layout does not break even if there is an overflow
- [-] Layout does not break when wraps
- [-] Added new Component
  - [ ] Added data-* prop and id prop
- [-] Updated [Ubie Vitals](https://github.com/ubie-oss/ubie-vitals-website) or Added an update [issue](https://github.com/ubie-oss/ubie-vitals-website/issues)(if needed)

