### PR TITLE
アコーディオンコンポーネントの見出しの下に説明を追加できるように

### DIFF
--- a/src/components/Accordion/Accordion.module.css
+++ b/src/components/Accordion/Accordion.module.css
@@ -29,6 +29,7 @@
   width: 100%;
   min-height: 2rem;
   padding: var(--size-spacing-md);
+  font-weight: bold;
   border-radius: var(--radius-md);
 }
 
@@ -36,28 +37,9 @@
   width: 100%;
   min-height: 1.5rem;
   padding: var(--size-spacing-xs);
+  font-size: var(--text-button-md-size);
   border-right: none;
   border-left: none;
-}
-
-.text {
-  display: flex;
-  flex-direction: column;
-  gap: var(--size-spacing-xxs);
-}
-
-.medium .header {
-  font-weight: bold;
-}
-
-.small .header {
-  font-size: var(--text-button-md-size);
-}
-
-.description {
-  font-size: var(--text-body-xs-size);
-  line-height: var(--text-body-xs-line);
-  color: var(--color-text-sub);
 }
 
 details[open] .button {

--- a/src/components/Accordion/Accordion.module.css
+++ b/src/components/Accordion/Accordion.module.css
@@ -29,7 +29,6 @@
   width: 100%;
   min-height: 2rem;
   padding: var(--size-spacing-md);
-  font-weight: bold;
   border-radius: var(--radius-md);
 }
 
@@ -37,9 +36,28 @@
   width: 100%;
   min-height: 1.5rem;
   padding: var(--size-spacing-xs);
-  font-size: var(--text-button-md-size);
   border-right: none;
   border-left: none;
+}
+
+.text {
+  display: flex;
+  flex-direction: column;
+  gap: var(--size-spacing-xxs);
+}
+
+.medium .header {
+  font-weight: bold;
+}
+
+.small .header {
+  font-size: var(--text-button-md-size);
+}
+
+.description {
+  font-size: var(--text-body-xs-size);
+  line-height: var(--text-body-xs-line);
+  color: var(--color-text-sub);
 }
 
 details[open] .button {

--- a/src/components/Accordion/Accordion.stories.tsx
+++ b/src/components/Accordion/Accordion.stories.tsx
@@ -12,6 +12,7 @@ const defaultArgs = {
   header: '夏目漱石「私の個人主義」',
   children:
     '何は時分どうもどんな観念顔というののところを云ったいまし。とうてい今日に説明院は現にこういう反対たますくらいから思わて来るないにも撲殺なるたたて、始終にも願うただですん。',
+  description: '出版日：1978年8月8日',
 } satisfies Partial<ComponentProps<typeof Accordion>>;
 
 export const Default: Story = {

--- a/src/components/Accordion/Accordion.tsx
+++ b/src/components/Accordion/Accordion.tsx
@@ -4,6 +4,8 @@ import { ArrowBDownIcon } from '@ubie/ubie-icons';
 import clsx from 'clsx';
 import styles from './Accordion.module.css';
 import { CustomDataAttributeProps } from '../../types/attributes';
+import { Stack } from '../Stack/Stack';
+import { Text } from '../Text/Text';
 import type { FC, ReactNode } from 'react';
 
 export type Size = 'small' | 'medium';
@@ -53,10 +55,16 @@ export const Accordion: FC<Props> = ({
   return (
     <details className={clsx(styles.container, styles[size])} id={id} {...props} open={initialOpen}>
       <summary id={buttonId} className={styles.button}>
-        <span className={styles.text}>
-          <span className={styles.header}>{header}</span>
-          {description && <span className={styles.description}>{description}</span>}
-        </span>
+        <Stack spacing="xxs" as="span">
+          <Text bold={size === 'medium'} leading="narrow" as="span" size={size === 'medium' ? 'md' : 'sm'}>
+            {header}
+          </Text>
+          {description && (
+            <Text color="sub" size="xs" as="span">
+              {description}
+            </Text>
+          )}
+        </Stack>
         <ArrowBDownIcon aria-hidden className={styles.arrow} />
       </summary>
       <div className={styles.panel}>{children}</div>

--- a/src/components/Accordion/Accordion.tsx
+++ b/src/components/Accordion/Accordion.tsx
@@ -18,6 +18,10 @@ type Props = {
    */
   header: string;
   /**
+   * 見出しの下に表示する説明
+   */
+  description?: string;
+  /**
    * サイズ
    * @default medium
    */
@@ -36,11 +40,23 @@ type Props = {
   initialOpen?: boolean;
 } & CustomDataAttributeProps;
 
-export const Accordion: FC<Props> = ({ header, children, size = 'medium', id, buttonId, initialOpen, ...props }) => {
+export const Accordion: FC<Props> = ({
+  header,
+  description,
+  children,
+  size = 'medium',
+  id,
+  buttonId,
+  initialOpen,
+  ...props
+}) => {
   return (
     <details className={clsx(styles.container, styles[size])} id={id} {...props} open={initialOpen}>
       <summary id={buttonId} className={styles.button}>
-        <span>{header}</span>
+        <span className={styles.text}>
+          <span className={styles.header}>{header}</span>
+          {description && <span className={styles.description}>{description}</span>}
+        </span>
         <ArrowBDownIcon aria-hidden className={styles.arrow} />
       </summary>
       <div className={styles.panel}>{children}</div>


### PR DESCRIPTION
# Changes
アコーディオンコンポーネントに`description`propを追加し、見出し下部に説明テキストを追加できるようにしました。

|before|after|
|----|----|
|![image](https://github.com/user-attachments/assets/1f9614f4-d94c-40b0-94a8-54641535f2d9)|![image](https://github.com/user-attachments/assets/a0dc6575-a09c-4218-a76a-dde056d456ea)


# Check

- [ ] Browser verification (minimum) Android Chrome/iOS Safari(375px-)
- [x] CSS not affected by inheritance
- [x] Layout does not break even if there is an overflow
- [x] Layout does not break when wraps
- [ ] ~~Added new Component~~
  - [ ] ~~Added data-* prop and id prop~~
- [ ] Updated [Ubie Vitals](https://github.com/ubie-oss/ubie-vitals-website) or Added an update [issue](https://github.com/ubie-oss/ubie-vitals-website/issues)(if needed)

