### PR TITLE
Add wide leading to Text (body, heading)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -69,7 +69,7 @@
       },
       "peerDependencies": {
         "@headlessui/react": "^2.0.0",
-        "@ubie/design-tokens": ">=0.3.2",
+        "@ubie/design-tokens": ">=0.3.3",
         "@ubie/ubie-icons": ">=0.5.0 <0.6.2 || >=0.8.0",
         "react": "^17 || ^18 || ^19",
         "react-dom": "^18 || ^19"
@@ -3713,9 +3713,9 @@
       }
     },
     "node_modules/@ubie/design-tokens": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@ubie/design-tokens/-/design-tokens-0.3.2.tgz",
-      "integrity": "sha512-zUGotkjK2nJ+oTFDjdFWq6p9exgaLl3/UBaBpUEAT6HEE6VlVEFWVUa4wpNbAgUr05suhTybSrKErAQXB0mCGQ==",
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@ubie/design-tokens/-/design-tokens-0.3.3.tgz",
+      "integrity": "sha512-/lb7EmTRyhbgjJxzQ6HyudP8GZ9Kp0UW2TmOoUj/BdtfdQEcooF/e0qK+XlmBk5bPMqD05wTjySXfmgugF2G7w==",
       "license": "Apache-2.0",
       "peer": true
     },

--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
   },
   "peerDependencies": {
     "@headlessui/react": "^2.0.0",
-    "@ubie/design-tokens": ">=0.3.2",
+    "@ubie/design-tokens": ">=0.3.3",
     "@ubie/ubie-icons": ">=0.5.0 <0.6.2 || >=0.8.0",
     "react": "^17 || ^18 || ^19",
     "react-dom": "^18 || ^19"

--- a/src/components/Text/Text.module.css
+++ b/src/components/Text/Text.module.css
@@ -143,6 +143,14 @@ button.text.link:focus-visible {
   --leading: var(--text-body-md-narrow-line);
 }
 
+.wide {
+  --leading: var(--text-body-md-wide-line);
+}
+
+.wide.heading {
+  --leading: var(--text-heading-md-wide-line);
+}
+
 .left {
   text-align: left;
 }

--- a/src/stories/Text.stories.tsx
+++ b/src/stories/Text.stories.tsx
@@ -54,38 +54,75 @@ export const Heading: Story = {
     const headingText = '近くの医療機関から調べる';
 
     return (
-      <Flex spacing="md" alignItems="center">
-        <Text bold type="heading" size="xxs">
-          xxs
-          <br />
-          {`${headingText}`}
-        </Text>
-        <Text bold type="heading" size="xs">
-          xs
-          <br />
-          {`${headingText}`}
-        </Text>
-        <Text bold type="heading" size="sm">
-          sm
-          <br />
-          {`${headingText}`}
-        </Text>
-        <Text bold type="heading" size="md">
-          md
-          <br />
-          {`${headingText}`}
-        </Text>
-        <Text bold type="heading" size="lg">
-          lg
-          <br />
-          {`${headingText}`}
-        </Text>
-        <Text bold type="heading" size="xl">
-          xl
-          <br />
-          {`${headingText}`}
-        </Text>
-      </Flex>
+      <>
+        <p>Default Leading</p>
+        <Flex spacing="md" alignItems="center">
+          <Text bold type="heading" size="xxs">
+            xxs
+            <br />
+            {`${headingText}`}
+          </Text>
+          <Text bold type="heading" size="xs">
+            xs
+            <br />
+            {`${headingText}`}
+          </Text>
+          <Text bold type="heading" size="sm">
+            sm
+            <br />
+            {`${headingText}`}
+          </Text>
+          <Text bold type="heading" size="md">
+            md
+            <br />
+            {`${headingText}`}
+          </Text>
+          <Text bold type="heading" size="lg">
+            lg
+            <br />
+            {`${headingText}`}
+          </Text>
+          <Text bold type="heading" size="xl">
+            xl
+            <br />
+            {`${headingText}`}
+          </Text>
+        </Flex>
+
+        <p style={{ marginTop: '16px' }}>Wide Leading</p>
+        <Flex spacing="md" alignItems="center">
+          <Text bold leading="wide" type="heading" size="xxs">
+            xxs
+            <br />
+            {`${headingText}`}
+          </Text>
+          <Text bold leading="wide" type="heading" size="xs">
+            xs
+            <br />
+            {`${headingText}`}
+          </Text>
+          <Text bold leading="wide" type="heading" size="sm">
+            sm
+            <br />
+            {`${headingText}`}
+          </Text>
+          <Text bold leading="wide" type="heading" size="md">
+            md
+            <br />
+            {`${headingText}`}
+          </Text>
+          <Text bold leading="wide" type="heading" size="lg">
+            lg
+            <br />
+            {`${headingText}`}
+          </Text>
+          <Text bold leading="wide" type="heading" size="xl">
+            xl
+            <br />
+            {`${headingText}`}
+          </Text>
+        </Flex>
+      </>
     );
   },
   args: defaultArgs,
@@ -146,6 +183,34 @@ export const Body: Story = {
                 {`${bodyText}`}
               </Text>
               <Text leading="narrow" type="body" size="lg">
+                lg
+                <br />
+                {`${bodyText}`}
+              </Text>
+            </Flex>
+          </dd>
+        </div>
+
+        <div>
+          <dt>Wide Leading</dt>
+          <dd>
+            <Flex spacing="md" alignItems="center">
+              <Text leading="wide" type="body" size="xs">
+                xs
+                <br />
+                {`${bodyText}`}
+              </Text>
+              <Text leading="wide" type="body" size="sm">
+                sm
+                <br />
+                {`${bodyText}`}
+              </Text>
+              <Text leading="wide" type="body" size="md">
+                md
+                <br />
+                {`${bodyText}`}
+              </Text>
+              <Text leading="wide" type="body" size="lg">
                 lg
                 <br />
                 {`${bodyText}`}

--- a/src/types/style.ts
+++ b/src/types/style.ts
@@ -2,7 +2,7 @@ export type FontSize = 'xxs' | 'xs' | 'sm' | 'md' | 'lg' | 'xl';
 
 export type TextType = 'body' | 'heading' | 'button' | 'tag';
 
-export type Leading = 'default' | 'narrow';
+export type Leading = 'default' | 'narrow' | 'wide';
 
 export type Hue = 'black' | 'blue' | 'pink' | 'orange' | 'purple' | 'green' | 'red';
 
@@ -20,11 +20,11 @@ export type TextColorTokenKey =
 
 export type BodyFontSize = Extract<FontSize, 'xs' | 'sm' | 'md' | 'lg'>;
 
-export type BodyLeading = Extract<Leading, 'default' | 'narrow'>;
+export type BodyLeading = Extract<Leading, 'default' | 'narrow' | 'wide'>;
 
 export type HeadingFontSize = Extract<FontSize, 'xxs' | 'xs' | 'sm' | 'md' | 'lg' | 'xl'>;
 
-export type HeadingLeading = Extract<Leading, 'default'>;
+export type HeadingLeading = Extract<Leading, 'default' | 'wide'>;
 
 export type ButtonFontSize = Extract<FontSize, 'sm' | 'md' | 'lg'>;
 


### PR DESCRIPTION
# Changes

- use design-token 0.3.3
- Add wide leading attr to Text component (type: body heading)

# Check

- [x] Browser verification (minimum) Android Chrome/iOS Safari(375px-)
- [x] CSS not affected by inheritance
- [x] Layout does not break even if there is an overflow
- [x] Layout does not break when wraps
- [ ] Added new Component
  - [ ] Added data-* prop and id prop
- [ ] Updated [Ubie Vitals](https://github.com/ubie-oss/ubie-vitals-website) or Added an update [issue](https://github.com/ubie-oss/ubie-vitals-website/issues)(if needed)

