### PR TITLE
Fix overlapping suffixIcon when button is in loading state

### DIFF
--- a/src/components/Button/Button.module.css
+++ b/src/components/Button/Button.module.css
@@ -251,6 +251,10 @@
   vertical-align: middle;
 }
 
+.suffixIcon.loading {
+  opacity: 0;
+}
+
 .suffixIcon > * {
   width: var(--icon-size);
   height: var(--icon-size);

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -85,7 +85,7 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
         <span className={styles.label}>
           {prefixIcon && <span className={clsx(styles.icon, loading && styles.loading)}>{prefixIcon}</span>}
           <span className={clsx(styles.children, loading && styles.loading)}>{children}</span>
-          {suffixIcon && <span className={styles.suffixIcon}>{suffixIcon}</span>}
+          {suffixIcon && <span className={clsx(styles.suffixIcon, loading && styles.loading)}>{suffixIcon}</span>}
         </span>
       </button>
     );


### PR DESCRIPTION
# Changes

- Apply loading state to Button component suffix icon
  - Hide suffix icon while loading

# Check

- [ ] Browser verification (minimum) Android Chrome/iOS Safari(375px-)
- [ ] CSS not affected by inheritance
- [ ] Layout does not break even if there is an overflow
- [ ] Layout does not break when wraps
- [ ] Added new Component
  - [ ] Added data-* prop and id prop
- [ ] Updated [Ubie Vitals](https://github.com/ubie-oss/ubie-vitals-website) or Added an update [issue](https://github.com/ubie-oss/ubie-vitals-website/issues)(if needed)

