### PR TITLE
Allow ReactNode in ActionHalfModal header prop and enable stickyHeade…

### DIFF
--- a/src/components/ActionHalfModal/ActionHalfModal.stories.tsx
+++ b/src/components/ActionHalfModal/ActionHalfModal.stories.tsx
@@ -1,6 +1,10 @@
 import { Meta, StoryObj } from '@storybook/react';
 import { ComponentProps, useCallback, useState } from 'react';
 import { ActionHalfModal } from './ActionHalfModal';
+import { Box } from '../Box/Box';
+import { Button } from '../Button/Button';
+import { Flex } from '../Flex/Flex';
+import { Text } from '../Text/Text';
 
 export default {
   title: 'Modal/ActionHalfModal',
@@ -332,5 +336,96 @@ export const StickyHeaderAndFooter: Story = {
     ...defaultArgs,
     stickyHeader: true,
     stickyFooter: true,
+  },
+};
+
+export const ReactNodeHeader: Story = {
+  render: (args) => {
+    const [open, setOpen] = useState(true);
+
+    const onClose = useCallback(() => {
+      setOpen(false);
+    }, []);
+
+    return (
+      <>
+        <button type="button" onClick={() => setOpen(true)}>
+          Open Modal
+        </button>
+        <ActionHalfModal
+          primaryActionLabel="アクション"
+          onPrimaryAction={onClose}
+          {...args}
+          open={open}
+          onClose={onClose}
+        />
+      </>
+    );
+  },
+  args: {
+    ...defaultArgs,
+    header: (
+      <Box>
+        <Flex gap="xs" alignItems="center" justifyContent="space-between">
+          <Text size="lg" color="main">
+            カスタムヘッダー
+          </Text>
+          <Button variant="text" size="small">
+            設定
+          </Button>
+        </Flex>
+      </Box>
+    ),
+    stickyHeader: true,
+  },
+};
+
+export const ReactNodeHeaderWithHero: Story = {
+  render: (args) => {
+    const [open, setOpen] = useState(true);
+
+    const onClose = useCallback(() => {
+      setOpen(false);
+    }, []);
+
+    return (
+      <>
+        <button type="button" onClick={() => setOpen(true)}>
+          Open Modal
+        </button>
+        <ActionHalfModal
+          primaryActionLabel="アクション"
+          onPrimaryAction={onClose}
+          {...args}
+          open={open}
+          onClose={onClose}
+        />
+      </>
+    );
+  },
+  args: {
+    ...defaultArgs,
+    header: (
+      <Box>
+        <Flex gap="xs" alignItems="center" justifyContent="space-between">
+          <Text size="lg" color="main">
+            Hero付きカスタムヘッダー
+          </Text>
+          <Button variant="text" size="small">
+            メニュー
+          </Button>
+        </Flex>
+      </Box>
+    ),
+    hero: (
+      <img
+        src="/images/placeholder.svg"
+        alt="Illustration: Modal"
+        style={{ width: '100%', height: 'auto', verticalAlign: 'bottom' }}
+        width={560}
+        height={315}
+      />
+    ),
+    stickyHeader: true,
   },
 };

--- a/src/components/ActionHalfModal/ActionHalfModal.tsx
+++ b/src/components/ActionHalfModal/ActionHalfModal.tsx
@@ -23,9 +23,9 @@ type BaseProps = {
    */
   onClose: () => void;
   /**
-   * ヘッダーに表示する見出しテキスト
+   * ヘッダーに表示する見出しテキストまたはReactノード
    */
-  header?: string;
+  header?: string | ReactNode;
   /**
    * プライマリーアクションボタンのカラースキーム
    */
@@ -72,7 +72,6 @@ type BaseProps = {
   hero?: ReactNode;
   /**
    * ヘッダーを固定表示
-   * heroが指定されている場合は無効
    */
   stickyHeader?: boolean;
   /**
@@ -195,11 +194,7 @@ export const ActionHalfModal: FC<Props> = ({
                   <Dialog.Title
                     tabIndex={-1}
                     ref={initialFocusRef}
-                    className={clsx(
-                      styles.header,
-                      !hero && stickyHeader && styles.sticky,
-                      canScrollUp && styles.canScroll,
-                    )}
+                    className={clsx(styles.header, stickyHeader && styles.sticky, canScrollUp && styles.canScroll)}
                   >
                     {header}
                   </Dialog.Title>

--- a/src/components/ActionHalfModal/ActionHalfModal.tsx
+++ b/src/components/ActionHalfModal/ActionHalfModal.tsx
@@ -25,7 +25,7 @@ type BaseProps = {
   /**
    * ヘッダーに表示する見出しテキストまたはReactノード
    */
-  header?: string | ReactNode;
+  header?: ReactNode;
   /**
    * プライマリーアクションボタンのカラースキーム
    */
@@ -131,9 +131,9 @@ export const ActionHalfModal: FC<Props> = ({
 
   const dialogRef = useCallback(
     (node: HTMLDivElement | null) => {
-      if (node !== null && header == null && ariaLabelledby != null) {
+      if (node !== null && (header == null || header === undefined) && ariaLabelledby != null) {
         node.setAttribute('aria-labelledby', ariaLabelledby);
-      } else if (node !== null && header == null && ariaLabelledby == null) {
+      } else if (node !== null && (header == null || header === undefined) && ariaLabelledby == null) {
         node.removeAttribute('aria-labelledby');
       }
     },
@@ -177,7 +177,7 @@ export const ActionHalfModal: FC<Props> = ({
               [styles.fullscreen]: fullscreen,
             })}
           >
-            {header === undefined ? (
+            {header === undefined || header === null ? (
               <VisuallyHidden as="p" tabIndex={-1} ref={initialFocusRef}>
                 ダイアログ
               </VisuallyHidden>
@@ -185,12 +185,12 @@ export const ActionHalfModal: FC<Props> = ({
             <div className={styles.scrollContainer} ref={scrollContainerRef}>
               <div
                 className={clsx(styles.mainContent, {
-                  [styles.headerLess]: header === undefined && hero === undefined,
+                  [styles.headerLess]: (header === undefined || header === null) && hero === undefined,
                   [styles.fullscreen]: fullscreen,
                 })}
               >
                 {hero !== undefined ? <div className={styles.hero}>{hero}</div> : null}
-                {header !== undefined ? (
+                {header !== undefined && header !== null ? (
                   <Dialog.Title
                     tabIndex={-1}
                     ref={initialFocusRef}


### PR DESCRIPTION
# Changes

  - Allow ReactNode in ActionHalfModal header
  prop for flexible header content
  - Remove restriction that disabled
  stickyHeader when hero prop is present
  - Add ReactNodeHeader and
  ReactNodeHeaderWithHero stories to
  demonstrate new functionality
  - Change header prop type from `string` to
  `string | ReactNode` (maintains backward
  compatibility)

  ## Background
  Previously, the `header` prop only accepted
  strings, which limited the ability to create
   complex header layouts (e.g., title with
  action buttons). Additionally,
  `stickyHeader` was disabled when a `hero`
  prop was present, which was a technical
  limitation rather than an accessibility
  requirement.

  ## Changes Made
  1. Updated `header` prop type to `string |
  ReactNode`
  2. Removed `!hero &&` condition from
  stickyHeader logic
  3. Added documentation examples showing
  ReactNode usage
  4. Updated prop comments to reflect new
  capabilities

  # Check

  - [ ] Browser verification (minimum) Android
   Chrome/iOS Safari(375px-)
  - [ ] CSS not affected by inheritance
  - [ ] Layout does not break even if there is
   an overflow
  - [ ] Layout does not break when wraps
  - [ ] Added new Component
    - [ ] Added data-* prop and id prop
  - [ ] Updated [Ubie Vitals](https://github.c
  om/ubie-oss/ubie-vitals-website) or Added an
   update [issue](https://github.com/ubie-oss/
  ubie-vitals-website/issues)(if needed)

