### PR TITLE
revert: バージョンを0.0.43に戻す (for GH release action)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ubie/ubie-ui",
-  "version": "0.0.44",
+  "version": "0.0.43",
   "description": "React components for creating Ubie applications.",
   "types": "dist/index.d.ts",
   "files": [


### PR DESCRIPTION
## Summary
- package.jsonのバージョンを0.0.44から0.0.43に戻す
- GitHubActionsでバージョン管理を行うため手動でのバージョンアップを取り消し

## Test plan
- [x] package.jsonの変更のみであることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)