### PR TITLE
fix: モーダルのヘッダーがコンテンツで隠れる

### DIFF
--- a/src/components/ActionHalfModal/ActionHalfModal.module.css
+++ b/src/components/ActionHalfModal/ActionHalfModal.module.css
@@ -78,6 +78,9 @@
 .header.sticky {
   position: sticky;
   top: 0;
+
+  /* Ensure sticky header appears above content that might overlap it (e.g., with position or transform) */
+  z-index: 1;
 }
 
 .header.sticky.canScroll {
@@ -85,6 +88,14 @@
 }
 
 .body {
+  /*
+   * Ensure the header always appears in front of body content.
+   * - Place header and body in the same stacking context
+   * - Set body's z-index lower than header's z-index
+   * This prevents the header from being hidden by body content,
+   * regardless of how high z-index values are specified within the body.
+   */
+  z-index: 0;
   padding-right: var(--size-spacing-md);
   padding-left: var(--size-spacing-md);
 }

--- a/src/components/ActionModal/ActionModal.module.css
+++ b/src/components/ActionModal/ActionModal.module.css
@@ -73,6 +73,9 @@
 .header.sticky {
   position: sticky;
   top: 0;
+
+  /* Ensure sticky header appears above content that might overlap it (e.g., with position or transform) */
+  z-index: 1;
 }
 
 .header.sticky.canScroll {
@@ -80,6 +83,14 @@
 }
 
 .body {
+  /*
+   * Ensure the header always appears in front of body content.
+   * - Place header and body in the same stacking context
+   * - Set body's z-index lower than header's z-index
+   * This prevents the header from being hidden by body content,
+   * regardless of how high z-index values are specified within the body.
+   */
+  z-index: 0;
   padding-right: var(--size-spacing-md);
   padding-left: var(--size-spacing-md);
 }

--- a/src/components/MessageHalfModal/MessageHalfModal.module.css
+++ b/src/components/MessageHalfModal/MessageHalfModal.module.css
@@ -78,6 +78,9 @@
 .header.sticky {
   position: sticky;
   top: 0;
+
+  /* Ensure sticky header appears above content that might overlap it (e.g., with position or transform) */
+  z-index: 1;
 }
 
 .header.sticky.canScroll {
@@ -85,6 +88,14 @@
 }
 
 .body {
+  /*
+   * Ensure the header always appears in front of body content.
+   * - Place header and body in the same stacking context
+   * - Set body's z-index lower than header's z-index
+   * This prevents the header from being hidden by body content,
+   * regardless of how high z-index values are specified within the body.
+   */
+  z-index: 0;
   padding-right: var(--size-spacing-md);
   padding-left: var(--size-spacing-md);
 }

--- a/src/components/MessageModal/MessageModal.module.css
+++ b/src/components/MessageModal/MessageModal.module.css
@@ -73,6 +73,9 @@
 .header.sticky {
   position: sticky;
   top: 0;
+
+  /* Ensure sticky header appears above content that might overlap it (e.g., with position or transform) */
+  z-index: 1;
 }
 
 .header.sticky.canScroll {
@@ -80,6 +83,14 @@
 }
 
 .body {
+  /*
+   * Ensure the header always appears in front of body content.
+   * - Place header and body in the same stacking context
+   * - Set body's z-index lower than header's z-index
+   * This prevents the header from being hidden by body content,
+   * regardless of how high z-index values are specified within the body.
+   */
+  z-index: 0;
   padding-right: var(--size-spacing-md);
   padding-left: var(--size-spacing-md);
   text-align: center;


### PR DESCRIPTION
# Changes
モーダルの sticky header がコンテンツで隠れてしまう問題を修正しました。
例えば、モーダルのコンテンツとして Ubie UI の Button を配置した場合、スクロールすると sticky header がボタンで隠れてしまっていました。

## 変更対象のコンポーネント
- ActionHalfModal
- ActionModal
- MessageHalfModal
- MessageModal

## 具体的な変更内容
- .header.sticky に `z-index: 1;` を追加しました
- .body に `z-index: 0;` を追加しました
  - .body は [フレックスコンテナーの子であり、 z-index の値が auto 以外の要素](https://developer.mozilla.org/ja/docs/Web/CSS/CSS_positioned_layout/Stacking_context#:~:text=%E3%83%95%E3%83%AC%E3%83%83%E3%82%AF%E3%82%B9%E3%82%B3%E3%83%B3%E3%83%86%E3%83%8A%E3%83%BC%E3%81%AE%E5%AD%90%E3%81%A7%E3%81%82%E3%82%8A%E3%80%81%20z%2Dindex%20%E3%81%AE%E5%80%A4%E3%81%8C%20auto%20%E4%BB%A5%E5%A4%96%E3%81%AE%E8%A6%81%E7%B4%A0%E3%80%82) になるため、スタッキングコンテキストが発生します
  - z-index 的に .header > .body となるため、.header が手前に来ます
  - [スタッキングコンテキストのネストルール](https://developer.mozilla.org/ja/docs/Web/CSS/CSS_positioned_layout/Stacking_context#:~:text=%E9%87%8D%E3%81%AD%E5%90%88%E3%82%8F%E3%81%9B%E3%82%B3%E3%83%B3%E3%83%86%E3%82%AD%E3%82%B9%E3%83%88%E3%81%AF%E3%81%AF%E3%82%81%E8%BE%BC%E3%81%BF%E5%BC%8F%E3%81%A7%E3%81%99%E3%80%82%E8%A6%81%E7%B4%A0%E3%81%AE%E4%B8%AD%E8%BA%AB%E3%81%8C%E9%87%8D%E3%81%AD%E3%82%89%E3%82%8C%E3%81%9F%E5%BE%8C%E3%80%81%E3%81%9D%E3%81%AE%E8%A6%81%E7%B4%A0%E3%81%8C%E3%81%BE%E3%82%8B%E3%81%94%E3%81%A8%E3%80%81%E4%BB%8A%E5%BA%A6%E3%81%AF%E8%A6%AA%E3%81%AE%E9%87%8D%E3%81%AD%E5%90%88%E3%82%8F%E3%81%9B%E3%82%B3%E3%83%B3%E3%83%86%E3%82%AD%E3%82%B9%E3%83%88%E3%81%AE%E9%87%8D%E3%81%AD%E5%90%88%E3%82%8F%E3%81%9B%E9%A0%86%E3%81%AE%E4%B8%AD%E3%81%AB%E3%81%82%E3%82%8B%E3%81%A8%E3%81%BF%E3%81%AA%E3%81%95%E3%82%8C%E3%81%BE%E3%81%99%E3%80%82)により、モーダルの children でどれほど高い z-index を指定しても、常にヘッダーが手前に来ます
- z-index プロパティは他要素との暗黙的な関連が強く、マジックナンバー感も強いので、念のためコメントを書いています。

## 問題と修正の再現

https://github.com/user-attachments/assets/3afc5e28-07e9-4bd2-b2a2-161ba25cd9d1



# Check

- [ ] Browser verification (minimum) Android Chrome/iOS Safari(375px-)
- [x] CSS not affected by inheritance
- [x] Layout does not break even if there is an overflow
- [x] Layout does not break when wraps
- [ ] ~~Added new Component~~
  - [ ] ~~Added data-* prop and id prop~~
- [ ] Updated [Ubie Vitals](https://github.com/ubie-oss/ubie-vitals-website) or Added an update [issue](https://github.com/ubie-oss/ubie-vitals-website/issues)(if needed)

