### PR TITLE
fix: correct typo 'Witdh' → 'Width'

### DIFF
--- a/src/components/Flex/Flex.tsx
+++ b/src/components/Flex/Flex.tsx
@@ -4,7 +4,7 @@ import clsx from 'clsx';
 import { isValidElement, cloneElement, useMemo } from 'react';
 import styles from './Flex.module.css';
 import { CustomDataAttributeProps } from '../../types/attributes'; // 追加したインポート
-import { AlignItems, CSSWitdh, FlexDirection, JustifyContent, Spacing, WidthProps } from '../../types/style';
+import { AlignItems, CSSWidth, FlexDirection, JustifyContent, Spacing, WidthProps } from '../../types/style';
 import { gapVariables, marginVariables, paddingVariables, widthVariables } from '../../utils/style';
 import { HTMLTagname } from '../../utils/types';
 import { Box } from '../Box/Box';
@@ -44,7 +44,7 @@ type Props = {
    * 幅を指定。fullは後方互換のために残している
    * デフォルト<Flex>は横幅いっぱいを専有する。しかし例えば、フレックスコンテナの子要素として配置した場合、横幅が自身の子に合わせて小さくなる。これが不都合の場合に100%とする
    */
-  width?: 'full' | CSSWitdh;
+  width?: 'full' | CSSWidth;
   /**
    * inline-flexとして扱う
    */

--- a/src/components/FlexItem/FlexItem.tsx
+++ b/src/components/FlexItem/FlexItem.tsx
@@ -3,13 +3,13 @@
 import { clsx } from 'clsx';
 import { CSSProperties, forwardRef, type HTMLAttributes, type PropsWithChildren } from 'react';
 import styles from './FlexItem.module.css';
-import { CSSWitdh, MarginProps, PaddingProps, WidthProps } from '../../types/style';
+import { CSSWidth, MarginProps, PaddingProps, WidthProps } from '../../types/style';
 import { marginVariables, paddingVariables } from '../../utils/style';
 
 type FlexProperty = {
   grow?: number;
   shrink?: number;
-  basis?: CSSWitdh;
+  basis?: CSSWidth;
 };
 
 type AllowedDivAttributes = Omit<HTMLAttributes<HTMLDivElement>, 'className'>;

--- a/src/types/style.ts
+++ b/src/types/style.ts
@@ -189,7 +189,7 @@ export type CSSPercentage = `${string}%`;
 
 export type CSSLengthPercentage = CSSLength | CSSPercentage;
 
-export type CSSWitdh =
+export type CSSWidth =
   | 'auto'
   | CSSLengthPercentage
   | 'min-content'
@@ -207,14 +207,14 @@ export type CSSMaxWidth =
   | `fit-content(${CSSLengthPercentage})`
   | CSSVariable;
 
-export type CSSMinWidth = CSSWitdh;
+export type CSSMinWidth = CSSWidth;
 
 export type WidthProps = {
   /**
    * 幅を指定
    * @default auto
    */
-  width?: CSSWitdh;
+  width?: CSSWidth;
   /**
    * 最小幅
    * @default auto

--- a/src/utils/style.ts
+++ b/src/utils/style.ts
@@ -13,7 +13,7 @@ import {
   TagLeading,
   CSSMinWidth,
   CSSMaxWidth,
-  CSSWitdh,
+  CSSWidth,
   TextColorVariant,
   TextColorTokenKey,
   BackgroundColorVariant,
@@ -270,7 +270,7 @@ export const widthVariables = ({
   minWidth = 'auto',
   maxWidth = 'none',
 }: {
-  width?: CSSWitdh;
+  width?: CSSWidth;
   minWidth?: CSSMinWidth;
   maxWidth?: CSSMaxWidth;
 }) => {


### PR DESCRIPTION
# Changes
TypeScriptの型定義において、`Witdh` という誤字を `Width` に修正しました。
型定義の修正のみのため、機能的な変更はありません。

# Check

- [ ] Browser verification (minimum) Android Chrome/iOS Safari(375px-)
- [x] CSS not affected by inheritance
- [x] Layout does not break even if there is an overflow
- [x] Layout does not break when wraps
- [ ] ~~Added new Component~~
  - [ ] ~~Added data-* prop and id prop~~
- [ ] Updated [Ubie Vitals](https://github.com/ubie-oss/ubie-vitals-website) or Added an update [issue](https://github.com/ubie-oss/ubie-vitals-website/issues)(if needed)

