### PR TITLE
Add maxHeight prop to ActionHalfModal

### DIFF
--- a/src/components/ActionHalfModal/ActionHalfModal.module.css
+++ b/src/components/ActionHalfModal/ActionHalfModal.module.css
@@ -30,7 +30,6 @@
   flex-direction: column;
   width: 100%;
   max-width: 600px;
-  max-height: calc(100% - 24px);
   margin: 0 auto;
   overflow-y: hidden;
   background: #fff;

--- a/src/components/ActionHalfModal/ActionHalfModal.stories.tsx
+++ b/src/components/ActionHalfModal/ActionHalfModal.stories.tsx
@@ -429,3 +429,32 @@ export const ReactNodeHeaderWithHero: Story = {
     stickyHeader: true,
   },
 };
+
+export const CustomMaxHeight: Story = {
+  render: (args) => {
+    const [open, setOpen] = useState(false);
+
+    const onClose = useCallback(() => {
+      setOpen(false);
+    }, []);
+
+    return (
+      <>
+        <button type="button" onClick={() => setOpen(true)}>
+          Open Modal
+        </button>
+        <ActionHalfModal
+          primaryActionLabel="アクション"
+          onPrimaryAction={onClose}
+          {...args}
+          open={open}
+          onClose={onClose}
+        />
+      </>
+    );
+  },
+  args: {
+    ...defaultArgs,
+    maxHeight: '80vh',
+  },
+};

--- a/src/components/ActionHalfModal/ActionHalfModal.tsx
+++ b/src/components/ActionHalfModal/ActionHalfModal.tsx
@@ -10,6 +10,7 @@ import { CustomDataAttributeProps } from '../../types/attributes';
 import { opacityToClassName } from '../../utils/style';
 import { AllOrNone } from '../../utils/types';
 import { Button } from '../Button/Button';
+import type { CSSMaxHeight } from '../../types/style';
 
 type Opacity = 'normal' | 'darker';
 
@@ -78,6 +79,11 @@ type BaseProps = {
    * フッターを固定表示
    */
   stickyFooter?: boolean;
+  /**
+   * モーダルの最大の高さ
+   * @default calc(100% - 24px)
+   */
+  maxHeight?: CSSMaxHeight;
 };
 
 type PrimaryActionProps = {
@@ -123,6 +129,7 @@ export const ActionHalfModal: FC<Props> = ({
   hero,
   stickyHeader = false,
   stickyFooter = false,
+  maxHeight = 'calc(100% - 24px)',
   ...props
 }) => {
   const opacityClassName = opacityToClassName(overlayOpacity);
@@ -176,6 +183,7 @@ export const ActionHalfModal: FC<Props> = ({
             className={clsx(styles.dialog, {
               [styles.fullscreen]: fullscreen,
             })}
+            style={{ maxHeight }}
           >
             {header === undefined || header === null ? (
               <VisuallyHidden as="p" tabIndex={-1} ref={initialFocusRef}>

--- a/src/components/Flex/Flex.tsx
+++ b/src/components/Flex/Flex.tsx
@@ -4,7 +4,7 @@ import clsx from 'clsx';
 import { isValidElement, cloneElement, useMemo } from 'react';
 import styles from './Flex.module.css';
 import { CustomDataAttributeProps } from '../../types/attributes'; // 追加したインポート
-import { AlignItems, CSSWitdh, FlexDirection, JustifyContent, Spacing, WidthProps } from '../../types/style';
+import { AlignItems, CSSWidth, FlexDirection, JustifyContent, Spacing, WidthProps } from '../../types/style';
 import { gapVariables, marginVariables, paddingVariables, widthVariables } from '../../utils/style';
 import { HTMLTagname } from '../../utils/types';
 import { Box } from '../Box/Box';
@@ -44,7 +44,7 @@ type Props = {
    * 幅を指定。fullは後方互換のために残している
    * デフォルト<Flex>は横幅いっぱいを専有する。しかし例えば、フレックスコンテナの子要素として配置した場合、横幅が自身の子に合わせて小さくなる。これが不都合の場合に100%とする
    */
-  width?: 'full' | CSSWitdh;
+  width?: 'full' | CSSWidth;
   /**
    * inline-flexとして扱う
    */

--- a/src/components/FlexItem/FlexItem.tsx
+++ b/src/components/FlexItem/FlexItem.tsx
@@ -3,13 +3,13 @@
 import { clsx } from 'clsx';
 import { CSSProperties, forwardRef, type HTMLAttributes, type PropsWithChildren } from 'react';
 import styles from './FlexItem.module.css';
-import { CSSWitdh, MarginProps, PaddingProps, WidthProps } from '../../types/style';
+import { CSSWidth, MarginProps, PaddingProps, WidthProps } from '../../types/style';
 import { marginVariables, paddingVariables } from '../../utils/style';
 
 type FlexProperty = {
   grow?: number;
   shrink?: number;
-  basis?: CSSWitdh;
+  basis?: CSSWidth;
 };
 
 type AllowedDivAttributes = Omit<HTMLAttributes<HTMLDivElement>, 'className'>;

--- a/src/types/style.ts
+++ b/src/types/style.ts
@@ -187,7 +187,9 @@ export type CSSLength =
 
 export type CSSPercentage = `${string}%`;
 
-export type CSSLengthPercentage = CSSLength | CSSPercentage;
+export type CSSCalc = `calc(${string})`;
+
+export type CSSLengthPercentage = CSSLength | CSSPercentage | CSSCalc;
 
 export type CSSWidth =
   | 'auto'

--- a/src/types/style.ts
+++ b/src/types/style.ts
@@ -189,7 +189,7 @@ export type CSSPercentage = `${string}%`;
 
 export type CSSLengthPercentage = CSSLength | CSSPercentage;
 
-export type CSSWitdh =
+export type CSSWidth =
   | 'auto'
   | CSSLengthPercentage
   | 'min-content'
@@ -207,14 +207,14 @@ export type CSSMaxWidth =
   | `fit-content(${CSSLengthPercentage})`
   | CSSVariable;
 
-export type CSSMinWidth = CSSWitdh;
+export type CSSMinWidth = CSSWidth;
 
 export type WidthProps = {
   /**
    * 幅を指定
    * @default auto
    */
-  width?: CSSWitdh;
+  width?: CSSWidth;
   /**
    * 最小幅
    * @default auto

--- a/src/types/style.ts
+++ b/src/types/style.ts
@@ -226,3 +226,27 @@ export type WidthProps = {
    */
   maxWidth?: CSSMaxWidth;
 };
+
+export type CSSHeight = CSSWidth;
+
+export type CSSMaxHeight = CSSMaxWidth;
+
+export type CSSMinHeight = CSSHeight;
+
+export type HeightProps = {
+  /**
+   * 高さを指定
+   * @default auto
+   */
+  height?: CSSHeight;
+  /**
+   * 最小高さ
+   * @default auto
+   */
+  minHeight?: CSSMinHeight;
+  /**
+   * 最大高さ
+   * @default none
+   */
+  maxHeight?: CSSMaxHeight;
+};

--- a/src/utils/style.ts
+++ b/src/utils/style.ts
@@ -13,7 +13,7 @@ import {
   TagLeading,
   CSSMinWidth,
   CSSMaxWidth,
-  CSSWitdh,
+  CSSWidth,
   TextColorVariant,
   TextColorTokenKey,
   BackgroundColorVariant,
@@ -270,7 +270,7 @@ export const widthVariables = ({
   minWidth = 'auto',
   maxWidth = 'none',
 }: {
-  width?: CSSWitdh;
+  width?: CSSWidth;
   minWidth?: CSSMinWidth;
   maxWidth?: CSSMaxWidth;
 }) => {


### PR DESCRIPTION
This PR depends on https://github.com/ubie-oss/ubie-ui/pull/162 .
Please merge #162 first. After that, I'll rebase this PR.

# Changes

モーダルの高さを自由に調整できるようにするため、ActionHalfModal コンポーネントに maxHeight プロパティを追加しました。

また、それに合わせて必要な変更を行いました：

- `src/types/style.ts` に Height 関連の型定義を追加
- CSSMaxHeight やその他の関連型で `calc()` を使えるようにする
  - width, max-width, height, max-height など `<length-percentage>` を受け付けるプロパティに対して、calc() を使用できるようにしました。
  - [MDN のドキュメント](https://developer.mozilla.org/en-US/docs/Web/CSS/calc#resulting_values)によると、calc() は `<length>` や `<percentage>`、またはそれらの組み合わせである `<length-percentage>` を返すことができる関数です。

## プレビュー
### Default
デフォルトの高さはこれまでと同じです
maxHeight = 'calc(100% - 24px)'
<img width="1000" alt="スクリーンショット 2025-08-07 17 01 27" src="https://github.com/user-attachments/assets/afeaa6b0-ab68-4b05-9e0c-6813f1943d2f" />

### Custom Max Height
maxHeight = '80vh'
<img width="1000" alt="image" src="https://github.com/user-attachments/assets/bd196530-f868-44c8-9961-3c7a4cae1148" />


# Check

- [x] Browser verification (minimum) Android Chrome/iOS Safari(375px-)
- [x] CSS not affected by inheritance
- [x] Layout does not break even if there is an overflow
- [x] Layout does not break when wraps
- [ ] ~~Added new Component~~
  - [ ] ~~Added data-* prop and id prop~~
- [ ] Updated [Ubie Vitals](https://github.com/ubie-oss/ubie-vitals-website) or Added an update [issue](https://github.com/ubie-oss/ubie-vitals-website/issues)(if needed)

