### PR TITLE
feat: Box コンポーネントの radius に 'full' を追加

### DIFF
--- a/src/stories/Box.stories.tsx
+++ b/src/stories/Box.stories.tsx
@@ -196,6 +196,9 @@ export const Radius: Story = {
       <Box {...args} mt="md" pt="md" pr="md" pb="md" pl="md" radius="lg">
         lg
       </Box>
+      <Box {...args} mt="md" pt="md" pr="md" pb="md" pl="md" radius="full">
+        full
+      </Box>
     </div>
   ),
   args: defaultArgs,

--- a/src/types/style.ts
+++ b/src/types/style.ts
@@ -125,7 +125,7 @@ export type JustifyContent =
   | 'space-around'
   | 'space-evenly';
 
-export type Radius = 'xs' | 'sm' | 'md' | 'lg';
+export type Radius = 'xs' | 'sm' | 'md' | 'lg' | 'full';
 
 export type RadiusProp = {
   /**


### PR DESCRIPTION
# Changes

円の中に画像を置くようなUIを作りたくなることが多いので、Boxコンポーネントで対応したい。

<img width="1656" height="457" alt="image" src="https://github.com/user-attachments/assets/054202a3-e6e9-4bb7-9c46-e5472368b9b3" />


# Check

- [ ] Browser verification (minimum) Android Chrome/iOS Safari(375px-)
- [ ] CSS not affected by inheritance
- [ ] Layout does not break even if there is an overflow
- [ ] Layout does not break when wraps
- [ ] Added new Component
  - [ ] Added data-* prop and id prop
- [ ] Updated [Ubie Vitals](https://github.com/ubie-oss/ubie-vitals-website) or Added an update [issue](https://github.com/ubie-oss/ubie-vitals-website/issues)(if needed)

