### PR TITLE
Remove UD Shin go from stepper css

### DIFF
--- a/src/components/Stepper/Stepper.module.css
+++ b/src/components/Stepper/Stepper.module.css
@@ -113,7 +113,7 @@
 
 .label {
   width: 100%;
-  font-family: 'OT-UD Shin Go Pr6N', sans-serif;
+  font-family: sans-serif;
   font-size: 12px;
   line-height: 1.5;
   text-align: center;


### PR DESCRIPTION
# Changes

related to: https://github.com/ubie-inc/ofro/pull/8827

Stepper コンポーネントの font 指定を削除

# Check

- [ ] Browser verification (minimum) Android Chrome/iOS Safari(375px-)
- [ ] CSS not affected by inheritance
- [ ] Layout does not break even if there is an overflow
- [ ] Layout does not break when wraps
- [ ] Added new Component
  - [ ] Added data-* prop and id prop
- [ ] Updated [Ubie Vitals](https://github.com/ubie-oss/ubie-vitals-website) or Added an update [issue](https://github.com/ubie-oss/ubie-vitals-website/issues)(if needed)

