### PR TITLE
fix: Stack/Center/Flex/BoxからSSR不要な'use client'を削除

### DIFF
--- a/src/components/Box/Box.tsx
+++ b/src/components/Box/Box.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import clsx from 'clsx';
 import styles from './Box.module.css';
 import {

--- a/src/components/Center/Center.tsx
+++ b/src/components/Center/Center.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import clsx from 'clsx';
 import {
   isValidElement,

--- a/src/components/Flex/Flex.tsx
+++ b/src/components/Flex/Flex.tsx
@@ -1,7 +1,5 @@
-'use client';
-
 import clsx from 'clsx';
-import { isValidElement, cloneElement, useMemo } from 'react';
+import { isValidElement, cloneElement } from 'react';
 import styles from './Flex.module.css';
 import { CustomDataAttributeProps } from '../../types/attributes'; // 追加したインポート
 import { AlignItems, CSSWidth, FlexDirection, JustifyContent, Spacing, WidthProps } from '../../types/style';
@@ -116,15 +114,7 @@ export const Flex: FC<PropsWithChildren<Props>> = ({
   };
 
   const width = _width === 'full' ? '100%' : _width;
-  const _spacing = useMemo(() => {
-    if (gap != null) {
-      return gap;
-    } else if (spacing != null) {
-      return spacing;
-    } else {
-      return undefined;
-    }
-  }, [gap, spacing]);
+  const _spacing = gap ?? spacing;
 
   return createElement(
     {

--- a/src/components/Stack/Stack.tsx
+++ b/src/components/Stack/Stack.tsx
@@ -1,7 +1,5 @@
-'use client';
-
 import { clsx } from 'clsx';
-import { cloneElement, isValidElement, useMemo } from 'react';
+import { cloneElement, isValidElement } from 'react';
 import styles from './Stack.module.css';
 import { CustomDataAttributeProps } from '../../types/attributes'; // 追加したインポート
 import { AlignItems, JustifyContent, Spacing, WidthProps } from '../../types/style';
@@ -103,15 +101,7 @@ export const Stack: FC<Props> = ({
     }
   };
 
-  const _spacing = useMemo(() => {
-    if (gap != null) {
-      return gap;
-    } else if (spacing != null) {
-      return spacing;
-    } else {
-      return undefined;
-    }
-  }, [gap, spacing]);
+  const _spacing = gap ?? spacing;
 
   return createElement(
     {


### PR DESCRIPTION
## 問題

\`Stack\`・\`Center\`・\`Flex\`・\`Box\` はHTMLのシンタックスシュガーであり、\`useState\`・\`useEffect\`などのクライアント固有APIを一切使用していないが、\`'use client'\` が付いていた。

\`'use client'\` はApp Routerにおいてクライアント境界を作るディレクティブであり、純粋なレイアウトコンポーネントに付与することで以下の問題が生じる：

- **不要なクライアント境界の発生**: \`Stack\`等を使うServer Componentの子孫ツリー全体がクライアントバンドルに引き込まれ、Server Componentの恩恵（バンドルサイズ削減等）が失われる
- **使用箇所の制約**: \`'use client'\`コンポーネントの直接の子にServer Componentを置けなくなる

### なぜ \`'use client'\` が付いていたか

\`Stack\`・\`Flex\` では \`gap ?? spacing\` の単純な条件式に \`useMemo\` が使われていた。\`useMemo\` はReact hookであるため、App RouterではServer Componentで使用できず、ビルドエラーを避けるために \`'use client'\` が追加されたと考えられる。

しかしこの \`useMemo\` 自体に効果はない。\`_spacing\` は文字列（プリミティブ）であり参照安定化の意味がなく、またそれを使っている \`style\` オブジェクト自体がレンダリングのたびに新しい参照で作られるため、\`_spacing\` だけmemoしても何も変わらない。

結果として、効果のない \`useMemo\` が \`'use client'\` を必要とし、その \`'use client'\` が不要なクライアント境界を作るという連鎖が生じていた。

## 修正内容

- \`Stack\`・\`Center\`・\`Flex\`・\`Box\` から \`'use client'\` を削除
- \`Stack\`・\`Flex\` の無効な \`useMemo\` を \`gap ?? spacing\` の直接評価に置き換え

## 確認

- ビルド: ✅
- テスト (134件): ✅
- Lint: ✅
- Chromatic: ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)